### PR TITLE
Fix string-based dtype comparisons across metric functions

### DIFF
--- a/aidrin/structured_data_metrics/class_imbalance.py
+++ b/aidrin/structured_data_metrics/class_imbalance.py
@@ -4,6 +4,7 @@ import warnings
 from math import sqrt
 from celery.exceptions import SoftTimeLimitExceeded
 import numpy as np
+import pandas as pd
 # Configure matplotlib before importing pyplot
 import matplotlib
 matplotlib.use('Agg')  # Use non-interactive backend
@@ -359,7 +360,7 @@ def calc_imbalance_degree(df, column, dist_metric='EU'):
             raise ValueError(f"Target feature '{column}' not found in the dataset")
 
         # Check if the column has categorical data
-        if df[column].dtype in ['int64', 'float64'] and df[column].nunique() > 100:
+        if pd.api.types.is_numeric_dtype(df[column]) and df[column].nunique() > 100:
             raise ValueError(
                 f"Column '{column}' appears to be numerical with too many unique values ({df[column].nunique()})."
                 "Class imbalance analysis requires categorical data with fewer unique values."

--- a/aidrin/structured_data_metrics/correlation_score.py
+++ b/aidrin/structured_data_metrics/correlation_score.py
@@ -21,8 +21,8 @@ def calc_correlations(self: Task, columns: List[str], file_info):
     df = read_file(file_info)
     try:
         # Separate categorical and numerical columns
-        categorical_columns = df[columns].select_dtypes(include="object").columns
-        numerical_columns = df[columns].select_dtypes(exclude="object").columns
+        categorical_columns = df[columns].select_dtypes(include=["object", "string", "category"]).columns
+        numerical_columns = df[columns].select_dtypes(exclude=["object", "string", "category"]).columns
 
         result_dict = {
             "Correlations Analysis Categorical": {},

--- a/aidrin/structured_data_metrics/feature_relevance.py
+++ b/aidrin/structured_data_metrics/feature_relevance.py
@@ -228,7 +228,7 @@ def data_cleaning(self: Task, cat_cols, num_cols, target_col, file_info):
             print("No categorical columns to encode")
 
         # Encode target variable if categorical
-        if df_filtered[target_col].dtype == "object":
+        if pd.api.types.is_object_dtype(df_filtered[target_col]) or isinstance(df_filtered[target_col].dtype, pd.StringDtype):
             try:
                 print(f"Encoding target column {target_col}...")
                 le_target = LabelEncoder()

--- a/aidrin/structured_data_metrics/privacy_measure.py
+++ b/aidrin/structured_data_metrics/privacy_measure.py
@@ -62,7 +62,7 @@ def generate_single_attribute_MM_risk_scores(df, id_col, eval_cols, task=None):
         # Check data types - ensure quasi-identifiers are categorical or string
         non_categorical_cols = []
         for col in eval_cols:
-            if df[col].dtype in ['int64', 'float64'] and df[col].nunique() > 100:
+            if pd.api.types.is_numeric_dtype(df[col]) and df[col].nunique() > 100:
                 non_categorical_cols.append(col)
 
         if non_categorical_cols:

--- a/docs/source/limitations.rst
+++ b/docs/source/limitations.rst
@@ -22,7 +22,6 @@ What We Can Do
 - Analyze **DCAT and DataCite JSON metadata** for FAIR compliance.
 - Identify **missing or incomplete metadata elements**.
 - Work with **structured tabular datasets** (e.g., CSV, Excel) for basic data readiness checks.
-- Handle all **numpy numeric dtypes** (e.g., ``float32``, ``int32``, ``uint16``) and pandas 2.x ``StringDtype`` columns correctly across all metric computations — not just the default ``float64``/``int64`` types produced by CSV parsing.
 
 What We Cannot Do
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/limitations.rst
+++ b/docs/source/limitations.rst
@@ -22,6 +22,7 @@ What We Can Do
 - Analyze **DCAT and DataCite JSON metadata** for FAIR compliance.
 - Identify **missing or incomplete metadata elements**.
 - Work with **structured tabular datasets** (e.g., CSV, Excel) for basic data readiness checks.
+- Handle all **numpy numeric dtypes** (e.g., ``float32``, ``int32``, ``uint16``) and pandas 2.x ``StringDtype`` columns correctly across all metric computations — not just the default ``float64``/``int64`` types produced by CSV parsing.
 
 What We Cannot Do
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -77,7 +77,11 @@ Calculates correlations between specified columns (numerical or categorical). Yo
    from aidrin import calculate_correlations
    result = calculate_correlations(columns=['age', 'education.num'], file_info=file_info)
 
-**Returns**: A dictionary with numerical correlation scores (using Pearson’s coefficient) and categorical correlation analysis using Theil's U statistic. It will also return a visualization (heatmap) of the correlations.
+**Returns**: A dictionary with numerical correlation scores (using Pearson’s coefficient) and categorical correlation analysis using Theil’s U statistic. It will also return a visualization (heatmap) of the correlations.
+
+.. note::
+
+   Column classification (categorical vs. numerical) correctly handles pandas 2.x ``StringDtype`` and ``category`` dtype columns, as well as narrow numeric types such as ``float32`` and ``int32`` produced by HDF5 or scientific data loaders.
 
 calculate_class_distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,6 +96,10 @@ Analyzes class distribution in a specified column to quantify imbalance. The `co
    result = calculate_class_distribution(column='income', file_info=file_info)
 
 **Returns**: A dictionary with an imbalance degree score and a pie chart visualization of the class distribution.
+
+.. note::
+
+   Columns with narrow numeric dtypes such as ``float32`` or ``int32`` (common in HDF5 and scientific datasets) are correctly identified as numerical and rejected if they have too many unique values. Only genuinely categorical columns should be passed as the ``column`` parameter.
 
 calculate_duplicates
 ^^^^^^^^^^^^^^^^^^^^
@@ -120,6 +128,10 @@ Assesses feature relevance relative to a given target column. Categorical featur
    result = calculate_feature_relevance(file_info=file_info, target_col='income')
 
 **Returns**: A dictionary with feature importance scores for the target column. A bar chart visualization of feature importances is also provided.
+
+.. note::
+
+   The ``target_col`` can be an ``object``-dtype column or a pandas 2.x ``StringDtype`` column — both are detected as categorical and label-encoded automatically before correlation is computed.
 
 calculate_outliers
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -79,10 +79,6 @@ Calculates correlations between specified columns (numerical or categorical). Yo
 
 **Returns**: A dictionary with numerical correlation scores (using Pearson’s coefficient) and categorical correlation analysis using Theil’s U statistic. It will also return a visualization (heatmap) of the correlations.
 
-.. note::
-
-   Column classification (categorical vs. numerical) correctly handles pandas 2.x ``StringDtype`` and ``category`` dtype columns, as well as narrow numeric types such as ``float32`` and ``int32`` produced by HDF5 or scientific data loaders.
-
 calculate_class_distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -96,10 +92,6 @@ Analyzes class distribution in a specified column to quantify imbalance. The `co
    result = calculate_class_distribution(column='income', file_info=file_info)
 
 **Returns**: A dictionary with an imbalance degree score and a pie chart visualization of the class distribution.
-
-.. note::
-
-   Columns with narrow numeric dtypes such as ``float32`` or ``int32`` (common in HDF5 and scientific datasets) are correctly identified as numerical and rejected if they have too many unique values. Only genuinely categorical columns should be passed as the ``column`` parameter.
 
 calculate_duplicates
 ^^^^^^^^^^^^^^^^^^^^
@@ -128,10 +120,6 @@ Assesses feature relevance relative to a given target column. Categorical featur
    result = calculate_feature_relevance(file_info=file_info, target_col='income')
 
 **Returns**: A dictionary with feature importance scores for the target column. A bar chart visualization of feature importances is also provided.
-
-.. note::
-
-   The ``target_col`` can be an ``object``-dtype column or a pandas 2.x ``StringDtype`` column — both are detected as categorical and label-encoded automatically before correlation is computed.
 
 calculate_outliers
 ^^^^^^^^^^^^^^^^^^

--- a/test_dtype_guards.py
+++ b/test_dtype_guards.py
@@ -1,0 +1,298 @@
+"""Regression tests for string-based dtype guards (fix/dtype-string-guards).
+
+These tests verify that metric functions correctly handle narrow numeric types
+(int32, float32) and pandas 2.x StringDtype columns, which the original
+string-based comparisons (dtype in ['int64', 'float64'], dtype == 'object',
+select_dtypes(include='object')) silently missed.
+"""
+
+import sys
+import types
+import unittest
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Pre-stub heavy modules so aidrin can be imported without a running app.
+# ---------------------------------------------------------------------------
+
+# pkg_resources stub (removed from Python 3.13 stdlib without setuptools;
+# needed by dython which is imported transitively by aidrin).
+if "pkg_resources" not in sys.modules:
+    _pkg = types.ModuleType("pkg_resources")
+
+    class _FakeDist:
+        def __init__(self):
+            self.version = "0.0.0"
+
+    _pkg.get_distribution = lambda _name: _FakeDist()
+    sys.modules["pkg_resources"] = _pkg
+
+# aidrin.file_handling.file_parser stub — privacy_measure.py imports read_file
+# at module level, which triggers file_parser → readers → Flask context deps.
+# Stubbing the module in sys.modules before any aidrin import prevents that.
+# We do NOT stub 'aidrin' itself so the real package is still loaded.
+if "aidrin.file_handling.file_parser" not in sys.modules:
+
+    class _FileParserStub(types.ModuleType):
+        read_file = staticmethod(lambda x: x)
+        SUPPORTED_FILE_TYPES = []
+        READER_MAP = {}
+
+        def __getattr__(self, name):
+            return None
+
+    _fp = _FileParserStub("aidrin.file_handling.file_parser")
+    sys.modules["aidrin.file_handling.file_parser"] = _fp
+
+# ---------------------------------------------------------------------------
+# Import functions under test (after stubs are in place)
+# ---------------------------------------------------------------------------
+
+from aidrin.structured_data_metrics.class_imbalance import calc_imbalance_degree  # noqa: E402
+from aidrin.structured_data_metrics.privacy_measure import (  # noqa: E402
+    generate_single_attribute_MM_risk_scores,
+)
+
+
+# ===========================================================================
+# class_imbalance.py — calc_imbalance_degree
+# ===========================================================================
+
+
+class TestCalcImbalanceDegreeNarrowDtypes(unittest.TestCase):
+    """float32/int32 columns with many unique values must be caught as numeric."""
+
+    def _many_unique(self, dtype):
+        return pd.DataFrame({"target": np.arange(200, dtype=dtype)})
+
+    # calc_imbalance_degree catches ValueError internally and returns {"Error": ...}
+    # rather than re-raising, so we check the returned dict, not raised exceptions.
+
+    # --- regression: narrow types now rejected (were silently passed before) ---
+
+    def test_float32_many_unique_rejects(self):
+        result = calc_imbalance_degree(self._many_unique(np.float32), "target")
+        self.assertIn("Error", result, "float32 with 200 uniques should return an error dict")
+
+    def test_int32_many_unique_rejects(self):
+        result = calc_imbalance_degree(self._many_unique(np.int32), "target")
+        self.assertIn("Error", result, "int32 with 200 uniques should return an error dict")
+
+    def test_uint16_many_unique_rejects(self):
+        result = calc_imbalance_degree(self._many_unique(np.uint16), "target")
+        self.assertIn("Error", result, "uint16 with 200 uniques should return an error dict")
+
+    # --- existing dtypes still caught ---
+
+    def test_float64_many_unique_rejects(self):
+        result = calc_imbalance_degree(self._many_unique(np.float64), "target")
+        self.assertIn("Error", result)
+
+    def test_int64_many_unique_rejects(self):
+        result = calc_imbalance_degree(self._many_unique(np.int64), "target")
+        self.assertIn("Error", result)
+
+    # --- few unique values → accepted (valid categorical-encoded column) ---
+
+    def test_float32_few_unique_passes(self):
+        df = pd.DataFrame(
+            {"target": pd.array([1.0, 2.0, 3.0, 1.0, 2.0] * 10, dtype="float32")}
+        )
+        result = calc_imbalance_degree(df, "target")
+        self.assertNotIn("Error", result)
+        self.assertIn("Imbalance Degree score", result)
+
+    def test_int32_few_unique_passes(self):
+        df = pd.DataFrame(
+            {"target": pd.array([0, 1, 2, 0, 1] * 10, dtype="int32")}
+        )
+        result = calc_imbalance_degree(df, "target")
+        self.assertNotIn("Error", result)
+        self.assertIn("Imbalance Degree score", result)
+
+
+# ===========================================================================
+# privacy_measure.py — generate_single_attribute_MM_risk_scores
+# ===========================================================================
+
+
+class TestGenerateSingleAttributeRiskNarrowDtypes(unittest.TestCase):
+    """float32/int32 quasi-id columns with high cardinality must be rejected."""
+
+    def _high_cardinality_df(self, qi_dtype):
+        n = 200  # > 100 unique values threshold
+        return pd.DataFrame(
+            {
+                "id": np.arange(n),
+                "qi": np.arange(n, dtype=qi_dtype),
+            }
+        )
+
+    # --- regression: narrow types now rejected ---
+
+    def test_float32_high_cardinality_rejects(self):
+        result = generate_single_attribute_MM_risk_scores(
+            self._high_cardinality_df(np.float32), "id", ["qi"]
+        )
+        self.assertIn("Error", result)
+        self.assertIn("numerical", result["Error"].lower())
+
+    def test_int32_high_cardinality_rejects(self):
+        result = generate_single_attribute_MM_risk_scores(
+            self._high_cardinality_df(np.int32), "id", ["qi"]
+        )
+        self.assertIn("Error", result)
+        self.assertIn("numerical", result["Error"].lower())
+
+    def test_uint16_high_cardinality_rejects(self):
+        result = generate_single_attribute_MM_risk_scores(
+            self._high_cardinality_df(np.uint16), "id", ["qi"]
+        )
+        self.assertIn("Error", result)
+
+    # --- existing dtypes still caught ---
+
+    def test_float64_high_cardinality_rejects(self):
+        result = generate_single_attribute_MM_risk_scores(
+            self._high_cardinality_df(np.float64), "id", ["qi"]
+        )
+        self.assertIn("Error", result)
+
+    def test_int64_high_cardinality_rejects(self):
+        result = generate_single_attribute_MM_risk_scores(
+            self._high_cardinality_df(np.int64), "id", ["qi"]
+        )
+        self.assertIn("Error", result)
+
+
+# ===========================================================================
+# correlation_score.py — select_dtypes dtype classification (fixed logic)
+# ===========================================================================
+
+
+class TestSelectDtypesStringClassification(unittest.TestCase):
+    """
+    The fixed select_dtypes expressions classify pd.StringDtype() columns as
+    categorical, not numerical.  These tests duplicate the logic from
+    calc_correlations() lines 24-25 so we can verify them without Celery.
+    """
+
+    _CATEGORICAL_INCLUDE = ["object", "string", "category"]
+    _NUMERICAL_EXCLUDE = ["object", "string", "category"]
+
+    def _classify(self, df, col):
+        cat = df.select_dtypes(include=self._CATEGORICAL_INCLUDE).columns
+        if col in cat:
+            return "categorical"
+        num = df.select_dtypes(exclude=self._NUMERICAL_EXCLUDE).columns
+        if col in num:
+            return "numerical"
+        return "unclassified"
+
+    # --- regression: StringDtype now treated as categorical ---
+
+    def test_string_dtype_is_categorical(self):
+        df = pd.DataFrame({"s": pd.array(["a", "b", "c"], dtype=pd.StringDtype())})
+        self.assertEqual(self._classify(df, "s"), "categorical")
+
+    def test_category_dtype_is_categorical(self):
+        df = pd.DataFrame({"cat": pd.Categorical(["x", "y", "x"])})
+        self.assertEqual(self._classify(df, "cat"), "categorical")
+
+    # --- existing behavior preserved ---
+
+    def test_object_dtype_is_categorical(self):
+        df = pd.DataFrame({"s": ["a", "b", "c"]})
+        self.assertEqual(self._classify(df, "s"), "categorical")
+
+    def test_float32_is_numerical(self):
+        df = pd.DataFrame({"n": pd.array([1.0, 2.0, 3.0], dtype="float32")})
+        self.assertEqual(self._classify(df, "n"), "numerical")
+
+    def test_int32_is_numerical(self):
+        df = pd.DataFrame({"n": pd.array([1, 2, 3], dtype="int32")})
+        self.assertEqual(self._classify(df, "n"), "numerical")
+
+    def test_float64_is_numerical(self):
+        df = pd.DataFrame({"n": [1.0, 2.0, 3.0]})
+        self.assertEqual(self._classify(df, "n"), "numerical")
+
+    def test_int64_is_numerical(self):
+        df = pd.DataFrame({"n": [1, 2, 3]})
+        self.assertEqual(self._classify(df, "n"), "numerical")
+
+    # --- pre-fix behaviour: StringDtype would fall into numerical (regression guard) ---
+
+    def test_old_include_object_misses_string_dtype(self):
+        """Demonstrates the pre-fix bug: select_dtypes(include='object') omits StringDtype."""
+        df = pd.DataFrame({"s": pd.array(["a", "b", "c"], dtype=pd.StringDtype())})
+        old_categorical = df.select_dtypes(include="object").columns
+        self.assertNotIn(
+            "s",
+            old_categorical,
+            "StringDtype column must NOT appear in old-style select_dtypes(include='object') "
+            "— confirming the bug we fixed.",
+        )
+
+
+# ===========================================================================
+# feature_relevance.py — target column dtype detection (fixed logic)
+# ===========================================================================
+
+
+class TestTargetColDtypeDetection(unittest.TestCase):
+    """
+    The fixed condition in data_cleaning() detects pd.StringDtype() target
+    columns in addition to object-dtype columns, triggering label encoding.
+    """
+
+    def _is_string_target(self, series):
+        """Mirrors the fixed condition at feature_relevance.py line 231."""
+        return pd.api.types.is_object_dtype(series) or isinstance(
+            series.dtype, pd.StringDtype
+        )
+
+    # --- regression: StringDtype now detected ---
+
+    def test_string_dtype_detected(self):
+        s = pd.Series(pd.array(["a", "b", "c"], dtype=pd.StringDtype()))
+        self.assertTrue(self._is_string_target(s))
+
+    # --- existing behaviour preserved ---
+
+    def test_object_dtype_detected(self):
+        s = pd.Series(["a", "b", "c"])
+        self.assertTrue(self._is_string_target(s))
+
+    def test_float32_not_string(self):
+        s = pd.Series(pd.array([1.0, 2.0, 3.0], dtype="float32"))
+        self.assertFalse(self._is_string_target(s))
+
+    def test_int32_not_string(self):
+        s = pd.Series(pd.array([1, 2, 3], dtype="int32"))
+        self.assertFalse(self._is_string_target(s))
+
+    def test_float64_not_string(self):
+        s = pd.Series([1.0, 2.0, 3.0])
+        self.assertFalse(self._is_string_target(s))
+
+    def test_int64_not_string(self):
+        s = pd.Series([1, 2, 3])
+        self.assertFalse(self._is_string_target(s))
+
+    # --- pre-fix regression guard ---
+
+    def test_old_check_misses_string_dtype(self):
+        """Demonstrates the pre-fix bug: dtype == 'object' misses StringDtype."""
+        s = pd.Series(pd.array(["a", "b", "c"], dtype=pd.StringDtype()))
+        old_result = s.dtype == "object"
+        self.assertFalse(
+            old_result,
+            "StringDtype must NOT equal 'object' — confirming the bug we fixed.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
While testing with datasets loaded from HDF5 files, I noticed that several metric functions were silently misbehaving when
columns had non-default numeric dtypes like `float32`, `int32`, or `uint16`. The root cause was a handful of checks like:
                                                                                                                                                                                                                                                 
  `if df[col].dtype in ['int64', 'float64']:`                 
                                                                                                                                                                                                                                                 
This only matches the two dtypes that CSV parsing happens to produce by default. HDF5, ROOT, and other scientific formats routinely give you `float32` temperature readings,` uint16` pixel values, `int32` indices — none of which matched, so the guards were silently skipped.

There was also a related issue in `correlation_score.py` and `feature_relevance.py` where `select_dtypes(include="object")` and `dtype == "object"` miss `pd.StringDtype()` columns, which pandas 2.x uses for explicitly string-typed data. Those columns were falling through into the numerical path and getting passed to Pearson correlation, which obviously makes no sense.

What changed:
- `class_imbalance.py` + `privacy_measure.py`: `replaced dtype in ['int64', 'float64']` with `pd.api.types.is_numeric_dtype()`, which correctly covers the full numpy dtype hierarchy
- `correlation_score.py`: updated `select_dtypes` to `include=["object", "string", "category"]` so StringDtype and Categorical columns are routed to the categorical analysis path
- `feature_relevance.py`: updated target column check to catch both object and `pd.StringDtype` targets
- `Added import pandas as pd` to `class_imbalance.py` (it was operating on DataFrames without ever importing pandas — worked by coincidence since `dtype in [...]` doesn't need it, but `pd.api.types` does)

Tests: 27 regression tests in `test_dtype_guards.py` — covers `float32`/`int32`/`uint16` rejection in class imbalance and privacy risk functions, `StringDtype` classification in correlations, and explicit "here's what the old code got wrong" regression guards so this doesn't quietly regress.