### PR TITLE
Fix/hdf5 multigroup metric isolation

### DIFF
--- a/aidrin/file_handling/readers/hdf5_reader.py
+++ b/aidrin/file_handling/readers/hdf5_reader.py
@@ -235,6 +235,8 @@ class hdf5Reader(BaseFileReader):
                 return None
 
             return df
+        except ValueError:
+            raise
         except Exception as e:
             self.logger.error(f"Error while reading: {e}")
             return None

--- a/aidrin/file_handling/readers/hdf5_reader.py
+++ b/aidrin/file_handling/readers/hdf5_reader.py
@@ -207,6 +207,16 @@ class hdf5Reader(BaseFileReader):
                     return
 
             with h5py.File(self.file_path, "r") as f:
+                top_level_groups = [
+                    name for name, obj in f.items() if isinstance(obj, h5py.Group)
+                ]
+                if len(top_level_groups) > 1:
+                    raise ValueError(
+                        f"HDF5 file contains multiple top-level groups: "
+                        f"{top_level_groups}. "
+                        f"Use the group selector on the upload page to choose "
+                        f"one group before running metrics."
+                    )
 
                 def visit(name, obj):
                     recurse(name, obj, name.strip("/").split("/"))

--- a/aidrin/main.py
+++ b/aidrin/main.py
@@ -28,6 +28,7 @@ from flask import (
 )
 from aidrin.file_handling.file_parser import (
     SUPPORTED_FILE_TYPES,
+    filter_file as fp_filter_file,
     read_file,
 )
 from aidrin.logging import setup_logging
@@ -301,6 +302,7 @@ def upload_file():
             # store the file path in the session
             session['uploaded_file_name'] = display_name
             session['uploaded_file_path'] = file_path
+            session['original_file_path'] = file_path
             session['uploaded_file_type'] = request.form.get('fileTypeSelector')
 
             return redirect(url_for('upload_file'))
@@ -410,9 +412,23 @@ def filter_file():
         else:
             keys_list = [str(keys)]
 
-        # Store the selected keys in session
+        # Store the selected keys in session for UI re-display
         session['selected_keys'] = keys_list
         session['minimize_preview'] = True
+
+        # Actually filter the file and update the active file path so that
+        # metric routes read the filtered dataset, not the full multi-group file.
+        original_path = session.get('original_file_path') or session.get('uploaded_file_path')
+        file_name = session.get('uploaded_file_name')
+        file_type = session.get('uploaded_file_type')
+
+        if original_path and file_type:
+            file_info = (original_path, file_name, file_type)
+            filtered_path = fp_filter_file(file_info, keys_list)
+            if filtered_path:
+                session['uploaded_file_path'] = filtered_path
+            else:
+                return jsonify({"success": False, "error": "Failed to create filtered file"}), 500
 
         return jsonify({"success": True, "message": "File filtered successfully"})
     except Exception as e:

--- a/test_hdf5_reader.py
+++ b/test_hdf5_reader.py
@@ -258,3 +258,80 @@ class TestCompletenessAccuracy:
 
         completeness = 1 - col.isnull().mean()
         assert abs(completeness - 0.6) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Multi-group guard: read() must reject files with multiple top-level groups
+# ---------------------------------------------------------------------------
+
+def _make_multigroup_hdf5(path, groups):
+    """Write an HDF5 file with multiple top-level groups, each holding one dataset."""
+    with h5py.File(path, "w") as f:
+        for group_name, data in groups.items():
+            g = f.create_group(group_name)
+            g.create_dataset("data", data=data)
+
+
+class TestMultiGroupGuard:
+
+    def test_read_raises_on_multiple_top_level_groups(self, tmp_path, logger):
+        """
+        hdf5Reader.read() must raise ValueError when the file has more than one
+        top-level group. Previously it would silently concatenate all groups into
+        a single misaligned DataFrame, causing wrong completeness scores.
+        """
+        fpath = str(tmp_path / "multi.h5")
+        _make_multigroup_hdf5(fpath, {
+            "sensors": np.arange(100, dtype=np.float64),
+            "waveforms": np.random.rand(50, 16),
+        })
+
+        with pytest.raises(ValueError, match="multiple top-level groups"):
+            hdf5Reader(fpath, logger).read()
+
+    def test_error_message_lists_group_names(self, tmp_path, logger):
+        """The ValueError message should name the offending groups so the user knows what to pick."""
+        fpath = str(tmp_path / "multi.h5")
+        _make_multigroup_hdf5(fpath, {
+            "injection": np.array([1.0, 2.0, 3.0]),
+            "seismicity": np.array([4.0, 5.0, 6.0]),
+        })
+
+        with pytest.raises(ValueError) as exc_info:
+            hdf5Reader(fpath, logger).read()
+
+        msg = str(exc_info.value)
+        assert "injection" in msg
+        assert "seismicity" in msg
+
+    def test_single_group_file_reads_without_error(self, tmp_path, logger):
+        """A file with exactly one top-level group should still read fine."""
+        fpath = str(tmp_path / "single.h5")
+        with h5py.File(fpath, "w") as f:
+            g = f.create_group("sensors")
+            g.create_dataset("temperature", data=np.array([20.0, 21.0, 22.0]))
+
+        df = hdf5Reader(fpath, logger).read()
+        assert df is not None
+        assert not df.empty
+
+    def test_completeness_not_inflated_by_group_misalignment(self, tmp_path, logger):
+        """
+        Regression: before the guard, uploading a file with groups of different
+        shapes produced a NaN-padded DataFrame. completeness() would report low
+        scores on a fully-populated dataset. Verify the guard prevents this by
+        ensuring a single-group file reports 100% completeness.
+        """
+        fpath = str(tmp_path / "single_full.h5")
+        with h5py.File(fpath, "w") as f:
+            g = f.create_group("measurements")
+            g.create_dataset("pressure", data=np.ones(200, dtype=np.float64))
+
+        df = hdf5Reader(fpath, logger).read()
+        assert df is not None
+
+        overall_completeness = 1 - df.isnull().any(axis=1).mean()
+        assert overall_completeness == 1.0, (
+            f"Expected 100% completeness for a fully-populated single-group file, "
+            f"got {overall_completeness:.2%}."
+        )


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

When uploading a multi-group HDF5 file and selecting specific groups on the upload page, the selection was only being saved to restore the UI checkmarks, the actual metric routes were still reading the full unfiltered file every time.

This meant completeness, outliers, and other scores were being computed on a DataFrame built by concatenating all groups together. If the groups had different shapes, pandas would fill the gaps with `NaN`, so you could end up with something like 32% completeness on a dataset that's actually fully populated. No error, just a quietly wrong result.

Fixed the filter route to actually write a filtered file and update the path that metrics read from. Also added a guard for the case where someone skips group selection on a multi-group file, instead of returning misleading scores, it now returns a clear message asking you to select a group first.

Added tests covering both cases: multi-group files correctly raise an error, and single-group files still read and report completeness accurately.

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
