### PR TITLE
fix: clear only session-owned files instead of entire upload folder

### DIFF
--- a/aidrin/main.py
+++ b/aidrin/main.py
@@ -302,6 +302,7 @@ def upload_file():
             session['uploaded_file_name'] = display_name
             session['uploaded_file_path'] = file_path
             session['uploaded_file_type'] = request.form.get('fileTypeSelector')
+            session['owned_files'] = [file_path]
 
             return redirect(url_for('upload_file'))
 
@@ -373,20 +374,14 @@ def retrieve_uploaded_file():
 @main.route('/clear', methods=['GET', 'POST'])
 def clear_file():
     file_upload_time_log.info("Clearing File")
-    # remove file path/name
-    session.pop("uploaded_file_path", None)
-    session.pop("uploaded_file_name", None)
-    session.pop("uploaded_file_type", None)
-    session.pop("minimize_preview", None)
+    owned_files = session.get('owned_files', [])
     session.clear()
-    upload_folder = current_app.config["UPLOAD_FOLDER"]
     try:
-        for filename in os.listdir(upload_folder):
-            file_path = os.path.join(upload_folder, filename)
-            if os.path.isfile(file_path):
+        for file_path in owned_files:
+            if file_path and os.path.isfile(file_path):
                 os.remove(file_path)
     except Exception as e:
-        file_upload_time_log.info("File Clear Failure: Unable to clear folder")
+        file_upload_time_log.info("File Clear Failure: Unable to clear files")
         return jsonify({"success": False, "error": str(e)}), 500
     return redirect(url_for("upload_file"))
 


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Found this while looking at the upload folder handling. When any user clicked "Clear", the code was looping through the entire shared upload folder and deleting every file in it, not just theirs. So if two people were using the app at the same time and one of them hit clear, the other person's file would just vanish mid-computation with no explanation.
Fixed it by tracking which files belong to which session at upload time, and only deleting those on clear.

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes