### PR TITLE
fix: StringDtype columns missing from feature dropdowns

### DIFF
--- a/aidrin/main.py
+++ b/aidrin/main.py
@@ -2381,7 +2381,7 @@ def get_summary_statistics():
         categorical_columns = [
             col
             for col, dtype in df.dtypes.items()
-            if pd.api.types.is_object_dtype(dtype)
+            if pd.api.types.is_object_dtype(dtype) or isinstance(dtype, pd.StringDtype)
         ]
         all_features = numerical_columns + categorical_columns
 
@@ -2477,7 +2477,7 @@ def extract_features():
 
         # Separate numerical and categorical columns
         numerical_columns = [col for col, dtype in df.dtypes.items() if pd.api.types.is_numeric_dtype(dtype)]
-        categorical_columns = [col for col, dtype in df.dtypes.items() if pd.api.types.is_object_dtype(dtype)]
+        categorical_columns = [col for col, dtype in df.dtypes.items() if pd.api.types.is_object_dtype(dtype) or isinstance(dtype, pd.StringDtype)]
         all_features = numerical_columns + categorical_columns
 
         # Filter features for Class Imbalance (30 or fewer unique values)


### PR DESCRIPTION
# Related Issues / Pull Requests

#64 (PR)

# Description

PR #64 fixed the dtype guards inside the metric functions themselves, but `main.py` was missed. The same `is_object_dtype()` check that was patched in `feature_relevance.py`, `correlation_score.py`, and others was still present in two places in `main.py`, the `/summary_statistics` and `/feature_set` routes that build the feature lists powering every metric page's dropdowns.

The result: any column with `pd.StringDtype` would pass neither the numeric nor the categorical check, so it simply didn't appear in the dropdown menus at all. Users could see the correct total feature count but couldn't actually select those columns for any metric. No error, just silently missing options.

Applied the same fix from #64 to both spots.

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
