### PR TITLE
Fix/reset index drop true

### DIFF
--- a/aidrin/__init__.py
+++ b/aidrin/__init__.py
@@ -13,7 +13,7 @@ def create_app():
     @app.context_processor
     def inject_version():
         return dict(app_version=__version__)  # global variable to access version in templates
-    app.secret_key = "aidrin"
+    app.secret_key = os.environ.get("AIDRIN_SECRET_KEY", "change-me-in-production") #Updated this env variable from static hardcoded to dynamic 
     # Celery Config
     app.config["CELERY"] = {
         "broker_url": "redis://localhost:6379/0",
@@ -50,6 +50,7 @@ def create_app():
     current_time = time.time()
     max_age_seconds = 3600  # 1 hour
     files_removed = 0
+
 
     for filename in os.listdir(UPLOAD_FOLDER):
         file_path = os.path.join(UPLOAD_FOLDER, filename)

--- a/aidrin/__init__.py
+++ b/aidrin/__init__.py
@@ -13,7 +13,7 @@ def create_app():
     @app.context_processor
     def inject_version():
         return dict(app_version=__version__)  # global variable to access version in templates
-    app.secret_key = os.environ.get("AIDRIN_SECRET_KEY", "aidrin") #Updated this env variable from static hardcoded to dynamic 
+    app.secret_key = os.environ.get("AIDRIN_SECRET_KEY", "aidrin") 
     # Celery Config
     app.config["CELERY"] = {
         "broker_url": "redis://localhost:6379/0",

--- a/aidrin/__init__.py
+++ b/aidrin/__init__.py
@@ -13,7 +13,7 @@ def create_app():
     @app.context_processor
     def inject_version():
         return dict(app_version=__version__)  # global variable to access version in templates
-    app.secret_key = os.environ.get("AIDRIN_SECRET_KEY", "change-me-in-production") #Updated this env variable from static hardcoded to dynamic 
+    app.secret_key = os.environ.get("AIDRIN_SECRET_KEY", "aidrin") #Updated this env variable from static hardcoded to dynamic 
     # Celery Config
     app.config["CELERY"] = {
         "broker_url": "redis://localhost:6379/0",

--- a/aidrin/__init__.py
+++ b/aidrin/__init__.py
@@ -13,7 +13,7 @@ def create_app():
     @app.context_processor
     def inject_version():
         return dict(app_version=__version__)  # global variable to access version in templates
-    app.secret_key = os.environ.get("AIDRIN_SECRET_KEY", "aidrin") 
+    app.secret_key = os.environ.get("AIDRIN_SECRET_KEY", "aidrin")
     # Celery Config
     app.config["CELERY"] = {
         "broker_url": "redis://localhost:6379/0",

--- a/aidrin/__init__.py
+++ b/aidrin/__init__.py
@@ -51,7 +51,6 @@ def create_app():
     max_age_seconds = 3600  # 1 hour
     files_removed = 0
 
-
     for filename in os.listdir(UPLOAD_FOLDER):
         file_path = os.path.join(UPLOAD_FOLDER, filename)
         try:

--- a/aidrin/structured_data_metrics/add_noise.py
+++ b/aidrin/structured_data_metrics/add_noise.py
@@ -29,7 +29,7 @@ def return_noisy_stats(add_noise_columns, epsilon, file_info):
     else:
         df = file_info
     df_drop_na = df.dropna()
-    df_drop_na = df_drop_na.reset_index(inplace=False)
+    df_drop_na = df_drop_na.reset_index(drop=True)
     if df_drop_na.empty:
         raise Exception("Dataset is empty")
 


### PR DESCRIPTION
# Related Issues / Pull Requests
Closes #90 

# Description
`reset_index()` was called without `drop=True` in `return_noisy_stats()`. This caused the old row indices to be saved as a new column called `index` in the in-memory DataFrame. Although the CSV output was unaffected due to `to_csv(index=False)`, the spurious column persisted throughout the function and could silently cause issues in future code changes.

Fixed by changing `inplace=False` to `drop=True`.

# What changes are proposed in this pull request?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:
- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [x] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

@kaveenh @jeanbez @sbyna @Aman-Cool 