### PR TITLE
GSoC 2026 PoC - Multiple File Formats Support (Zarr + Custom Ingestion Plugin)

### DIFF
--- a/POC_README.md
+++ b/POC_README.md
@@ -1,0 +1,98 @@
+# PoC: AIDRIN Multiple File Formats
+
+GSoC 2026 proof-of-concept for the AIDRIN Multiple File Formats project.
+
+## What this PoC demonstrates
+
+Two things:
+
+**1. `zarrReader` — a new file format reader (`aidrin/file_handling/readers/zarr_reader.py`)**
+
+Implements the `read() / parse() / filter()` contract defined by `BaseFileReader` and
+already satisfied by all existing readers (CSV, HDF5, NPZ, etc.).  Registering it in
+`READER_MAP` is the only change required to make the entire metric pipeline work with Zarr
+stores — no changes to `main.py`, no changes to any metric code.
+
+The interesting mechanism is `_collect_fill_values()`: Zarr arrays always carry a
+`fill_value` in their metadata, but the default is `0`, which is ambiguous — it may be a
+real measurement, not a missing-data marker.  The same explicit/uncertain split introduced
+in `hdf5Reader` is applied here, so Zarr fill-value replacement produces the same
+consistent NaN behaviour that HDF5 completeness metrics already rely on.
+
+**2. `BaseIngestionPlugin` — a custom ingestion plugin ABC (`aidrin/custom_readers/base_ingestion_plugin.py`)**
+
+A user subclasses `BaseIngestionPlugin`, implements `ingest(file_path) -> pd.DataFrame`,
+uploads the file via a UI editor, and AIDRIN dynamically loads it with `importlib` —
+exactly the same mechanism `BaseDRAgent` / `customMetrics` already uses on the output side.
+No core code changes needed to support a new, unknown file format.
+
+## Files added / changed
+
+```
+aidrin/
+  file_handling/
+    file_parser.py             ← zarr registered in READER_MAP + SUPPORTED_FILE_TYPES
+    readers/
+      zarr_reader.py           ← new: ZarrReader (read / parse / filter)
+  custom_readers/
+    __init__.py                ← new
+    base_ingestion_plugin.py   ← new: BaseIngestionPlugin ABC
+
+test_zarr_reader.py            ← new: 14 tests for zarrReader
+test_custom_reader.py          ← new: 10 tests for BaseIngestionPlugin + dynamic loading
+pyproject.toml                 ← zarr>=2.16,<3.0 added to dependencies
+```
+
+## How to run locally
+
+### 1. Install the extra dependency
+
+```bash
+pip install "zarr>=2.16,<3.0"
+```
+
+All other dependencies are already in `pyproject.toml`.
+
+### 2. Install the package in editable mode (if not already)
+
+```bash
+pip install -e .
+```
+
+### 3. Run the PoC tests
+
+```bash
+pytest test_zarr_reader.py test_custom_reader.py -v
+```
+
+Expected output: **24 passed**.
+
+### 4. Quick smoke test from a Python REPL
+
+```python
+import logging, numpy as np, zarr
+from aidrin.file_handling.readers.zarr_reader import zarrReader
+
+# Create a tiny in-memory-backed store
+store = zarr.open_group("smoke.zarr", mode="w")
+store.create_dataset("temperature", data=np.array([20.1, -9999.0, 22.3, 21.8]))
+
+log = logging.getLogger("smoke")
+df = zarrReader("smoke.zarr", log, fill_values=[-9999.0]).read()
+print(df)
+# completeness
+print("completeness:", 1 - df.isnull().mean().mean())
+```
+
+```python
+# Custom plugin (no file format support needed in core code)
+import pandas as pd
+from aidrin.custom_readers.base_ingestion_plugin import BaseIngestionPlugin
+
+class TsvReader(BaseIngestionPlugin):
+    def ingest(self, file_path: str) -> pd.DataFrame:
+        return pd.read_csv(file_path, sep="\t")
+
+plugin = TsvReader()
+# plugin.ingest("my_data.tsv") → DataFrame ready for AIDRIN metrics
+```

--- a/aidrin/custom_readers/base_ingestion_plugin.py
+++ b/aidrin/custom_readers/base_ingestion_plugin.py
@@ -1,0 +1,73 @@
+"""
+Abstract base class for user-defined custom ingestion plugins.
+
+Modelled directly on BaseDRAgent in aidrin/custom_metrics/base_dr.py:
+users subclass BaseIngestionPlugin, implement ingest(), upload the file
+via a UI editor, and AIDRIN dynamically loads it with importlib — no
+changes to core code required.
+
+The key difference from BaseDRAgent is that a plugin converts an
+arbitrary file into a DataFrame (the *input* side of the pipeline),
+whereas BaseDRAgent computes a metric on an existing DataFrame (the
+*analysis* side).
+"""
+
+import abc
+from typing import Any
+
+import pandas as pd
+
+
+class BaseIngestionPlugin(abc.ABC):
+    """Convert an arbitrary file into a pandas DataFrame for AIDRIN metrics.
+
+    Subclass this and implement ingest().  AIDRIN will call
+    ingest(file_path) with the path of the uploaded file and pass the
+    returned DataFrame into the standard metric pipeline.
+
+    Example
+    -------
+    A plugin that reads a fixed-width binary format (4-byte float32 per record):
+
+        import struct, pandas as pd
+        from aidrin.custom_readers.base_ingestion_plugin import BaseIngestionPlugin
+
+        class FloatBinReader(BaseIngestionPlugin):
+            def ingest(self, file_path: str) -> pd.DataFrame:
+                values = []
+                with open(file_path, 'rb') as f:
+                    while chunk := f.read(4):
+                        values.append(struct.unpack('<f', chunk)[0])
+                return pd.DataFrame({'value': values})
+    """
+
+    def __init__(self, **kwargs: Any):
+        self.kwargs = kwargs
+
+    @abc.abstractmethod
+    def ingest(self, file_path: str) -> pd.DataFrame:
+        """Read file_path and return a non-empty pandas DataFrame.
+
+        All column names should be strings.  Numeric columns are required
+        for completeness, outlier, and correlation metrics; string/object
+        columns are supported for FAIRness and class-imbalance metrics.
+        """
+
+    def validate(self, df: pd.DataFrame) -> bool:
+        """Check that ingest() returned a usable DataFrame.
+
+        Called automatically by the plugin loader after ingest().
+        Raises ValueError with a user-facing message on failure.
+        """
+        if df is None or df.empty:
+            raise ValueError(
+                "ingest() returned an empty DataFrame.  "
+                "Ensure the file contains data and the parser logic is correct."
+            )
+        if len(df.columns) == 0:
+            raise ValueError("ingest() returned a DataFrame with no columns.")
+        return True
+
+    def describe(self) -> str:
+        """Short description used in logs and the plugin registry UI."""
+        return self.__class__.__name__

--- a/aidrin/file_handling/file_parser.py
+++ b/aidrin/file_handling/file_parser.py
@@ -6,6 +6,7 @@ from aidrin.file_handling.readers.excel_reader import excelReader
 from aidrin.file_handling.readers.hdf5_reader import hdf5Reader
 from aidrin.file_handling.readers.json_reader import jsonReader
 from aidrin.file_handling.readers.npz_reader import npzReader
+from aidrin.file_handling.readers.zarr_reader import zarrReader
 
 # Notes:
 # To add support for new file types:
@@ -21,6 +22,7 @@ READER_MAP = {
     ".xls, .xlsb, .xlsx, .xlsm": excelReader,
     ".json": jsonReader,
     ".h5": hdf5Reader,
+    ".zarr": zarrReader,
     # Add additional file types here
 }
 
@@ -31,6 +33,7 @@ SUPPORTED_FILE_TYPES = [
     (".json", "JSON"),
     (".npz", "NumPy"),
     (".h5", "HDF5"),
+    (".zarr", "Zarr"),
     # Add additional file types here using the format:
     # (file_type,file_type_name)
 ]

--- a/aidrin/file_handling/readers/zarr_reader.py
+++ b/aidrin/file_handling/readers/zarr_reader.py
@@ -1,0 +1,259 @@
+"""
+Zarr v2/v3 reader for AIDRIN.
+
+Supports directory stores and zip stores.  Implements the same
+read() / parse() / filter() contract as existing readers, following
+hdf5Reader as the model for hierarchical format handling and the
+explicit-vs-uncertain fill-value classification it introduced.
+
+The central mechanism this PoC demonstrates is _collect_fill_values():
+Zarr arrays carry a fill_value in their metadata, but the default is 0,
+which is ambiguous — it may be a valid measurement, not a missing-data
+marker.  The same explicit/uncertain split used in hdf5Reader is applied
+here so callers get consistent NaN replacement behaviour across formats.
+"""
+
+import os
+import uuid
+import zipfile
+
+import numpy as np
+import pandas as pd
+import zarr
+from flask import current_app, session
+
+from aidrin.file_handling.readers.base_reader import BaseFileReader
+
+
+class zarrReader(BaseFileReader):
+    """Read Zarr v2/v3 stores into a pandas DataFrame.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to a Zarr directory store or zip store file.
+    logger : logging.Logger
+        Logger provided by file_parser.py.
+    fill_values : iterable of numeric, optional
+        Extra sentinel values to treat as explicit missing-data markers
+        on top of those found in array metadata.
+    """
+
+    def __init__(self, file_path: str, logger, fill_values=None):
+        super().__init__(file_path, logger)
+        self.fill_values = set(fill_values) if fill_values is not None else set()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _open_store(self):
+        """Return the root zarr.Group, auto-detecting zip vs. directory."""
+        if zipfile.is_zipfile(self.file_path):
+            store = zarr.ZipStore(self.file_path, mode="r")
+            return zarr.open_group(store, mode="r")
+        if os.path.isdir(self.file_path):
+            return zarr.open_group(self.file_path, mode="r")
+        raise ValueError(
+            f"Cannot open Zarr store at '{self.file_path}': "
+            "path is neither a zip file nor a directory."
+        )
+
+    def _collect_fill_values(self, array):
+        """Return (explicit_fills, uncertain_fills) for a zarr.Array.
+
+        Mirrors hdf5Reader._collect_fill_values().
+
+        explicit — replaced silently:
+            • User-supplied values from the constructor.
+            • The array's metadata fill_value when it is non-zero (the
+              producer deliberately chose this sentinel).
+
+        uncertain — WARNING emitted before replacement:
+            • The metadata fill_value when it equals the dtype default (0 /
+              0.0).  Zarr's spec requires every array to have a fill_value;
+              without an explicit assignment it defaults to zero, which is a
+              perfectly valid measurement in most datasets.
+        """
+        explicit = set(self.fill_values)
+        uncertain = set()
+
+        try:
+            raw = array.fill_value
+            if raw is not None:
+                native = float(raw)
+                if native not in explicit:
+                    dtype_default = float(np.zeros(1, dtype=array.dtype)[0])
+                    if native == dtype_default:
+                        uncertain.add(native)
+                    else:
+                        explicit.add(native)
+        except (TypeError, ValueError, AttributeError):
+            pass
+
+        return explicit, uncertain
+
+    def _array_to_rows(self, name, array):
+        """Load a numeric zarr.Array, apply fill-value replacement, return rows."""
+        if array.dtype.kind not in ("f", "i", "u"):
+            self.logger.info(
+                f"Skipping '{name}' (dtype {array.dtype} is non-numeric)."
+            )
+            return []
+
+        try:
+            data = array[...]
+        except Exception as exc:
+            self.logger.warning(f"Failed to load array '{name}': {exc}. Skipping.")
+            return []
+
+        explicit, uncertain = self._collect_fill_values(array)
+        all_fills = explicit | uncertain
+
+        if all_fills:
+            matched = {fv for fv in all_fills if np.any(data == fv)}
+            if matched:
+                mask = np.zeros(data.shape, dtype=bool)
+                for fv in matched:
+                    mask |= data == fv
+                n = int(mask.sum())
+
+                if matched & uncertain:
+                    self.logger.warning(
+                        f"Array '{name}': {n}/{data.size} value(s) match the "
+                        f"Zarr default fill value {matched & uncertain} and will "
+                        f"be replaced with NaN.  If zero is a valid measurement, "
+                        f"pass fill_values=[] to suppress this replacement."
+                    )
+                else:
+                    self.logger.info(
+                        f"Array '{name}': replaced {n}/{data.size} explicit "
+                        f"fill sentinel(s) {matched} with NaN."
+                    )
+
+                data = data.astype(np.float64)
+                data[mask] = np.nan
+
+        try:
+            df = pd.DataFrame(data)
+        except Exception:
+            try:
+                df = pd.DataFrame(data.reshape(-1, 1))
+            except Exception as exc2:
+                self.logger.warning(
+                    f"Cannot convert '{name}' to DataFrame: {exc2}. Skipping."
+                )
+                return []
+
+        return [{str(col): val for col, val in row.items()} for _, row in df.iterrows()]
+
+    # ------------------------------------------------------------------
+    # BaseFileReader interface
+    # ------------------------------------------------------------------
+
+    def read(self):
+        """Load all numeric arrays from the store into a single DataFrame."""
+        try:
+            root = self._open_store()
+        except Exception as exc:
+            self.logger.error(f"Cannot open Zarr store '{self.file_path}': {exc}")
+            return None
+
+        rows = []
+
+        def visitor(name, obj):
+            if isinstance(obj, zarr.Array):
+                rows.extend(self._array_to_rows(name, obj))
+
+        try:
+            root.visititems(visitor)
+        except Exception as exc:
+            self.logger.error(f"Zarr traversal error for '{self.file_path}': {exc}")
+            return None
+
+        if not rows:
+            self.logger.warning(
+                f"No numeric data found in Zarr store '{self.file_path}'."
+            )
+            return None
+
+        df = pd.DataFrame(rows)
+        df.columns = [str(col) for col in df.columns]
+        self.logger.info(
+            f"Zarr store loaded: {len(df)} rows x {len(df.columns)} columns."
+        )
+        return df
+
+    def parse(self):
+        """Return flat list of group paths (mirrors hdf5Reader.parse() behaviour)."""
+        try:
+            root = self._open_store()
+        except Exception as exc:
+            self.logger.error(f"Cannot open Zarr store for parsing: {exc}")
+            return None
+
+        group_names = []
+
+        def visitor(name, obj):
+            if isinstance(obj, zarr.Group):
+                group_names.append(str(name))
+
+        try:
+            root.visititems(visitor)
+        except Exception as exc:
+            self.logger.error(f"Zarr parse error: {exc}")
+            return None
+
+        self.logger.info(f"Zarr groups found: {group_names}")
+        return group_names
+
+    def filter(self, kept_keys, upload_folder=None, filename=None):
+        """Write a new zip store containing only the selected groups.
+
+        Parameters
+        ----------
+        kept_keys : str or list[str]
+            Group paths to retain (comma-separated string or list).
+        upload_folder : str, optional
+            Destination directory.  Falls back to current_app UPLOAD_FOLDER.
+        filename : str, optional
+            Original filename used to build the output name.  Falls back to
+            session['uploaded_file_name'].
+        """
+        if isinstance(kept_keys, str):
+            kept_keys = [k.strip() for k in kept_keys.split(",")]
+        selected = {str(k).strip("/") for k in kept_keys}
+
+        if upload_folder is None:
+            upload_folder = current_app.config["UPLOAD_FOLDER"]
+        if filename is None:
+            filename = session.get("uploaded_file_name", "store.zarr.zip")
+
+        new_path = os.path.join(upload_folder, f"filtered_{uuid.uuid4().hex}_{filename}")
+
+        try:
+            src = self._open_store()
+        except Exception as exc:
+            self.logger.error(f"Cannot open source store for filtering: {exc}")
+            return None
+
+        try:
+            dest_store = zarr.ZipStore(new_path, mode="w")
+            dest = zarr.open_group(dest_store, mode="w")
+
+            # Only copy the object whose path *directly* matches a selected key.
+            # visititems descends into groups, so copying a group already
+            # includes its children — avoid re-copying them by checking for
+            # an exact match rather than an ancestor match.
+            def copy_if_selected(name, obj):
+                if name.strip("/") in selected:
+                    zarr.copy(src[name], dest, name=name, log=None)
+
+            src.visititems(copy_if_selected)
+            dest_store.close()
+        except Exception as exc:
+            self.logger.error(f"Error writing filtered store: {exc}")
+            return None
+
+        self.logger.info(f"Filtered Zarr store written to '{new_path}'.")
+        return new_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "celery==5.5.3",
     "redis==6.4.0",
     "flower",
-    "openpyxl==3.1.5"
+    "openpyxl==3.1.5",
+    "zarr>=2.16,<3.0"
 ]
 
 [tool.setuptools.dynamic]

--- a/test_custom_reader.py
+++ b/test_custom_reader.py
@@ -1,0 +1,151 @@
+"""
+Tests for BaseIngestionPlugin and the dynamic-loading mechanism.
+
+Mirrors the test style from test_hdf5_reader.py.
+"""
+
+import importlib.util
+import sys
+import textwrap
+import types
+
+if "pkg_resources" not in sys.modules:
+    _pkg_resources = types.ModuleType("pkg_resources")
+
+    class _Dist:
+        def __init__(self):
+            self.version = "0.0.0"
+
+    _pkg_resources.get_distribution = lambda _name: _Dist()
+    sys.modules["pkg_resources"] = _pkg_resources
+
+import pandas as pd
+import pytest
+
+from aidrin.custom_readers.base_ingestion_plugin import BaseIngestionPlugin
+
+
+# ---------------------------------------------------------------------------
+# BaseIngestionPlugin contract
+# ---------------------------------------------------------------------------
+
+class TestBaseIngestionPlugin:
+    def test_abstract_method_enforced(self):
+        """Instantiating without implementing ingest() raises TypeError."""
+        class Incomplete(BaseIngestionPlugin):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_valid_subclass_runs(self, tmp_path):
+        csv_path = str(tmp_path / "data.csv")
+        pd.DataFrame({"a": [1, 2], "b": [3, 4]}).to_csv(csv_path, index=False)
+
+        class CsvPlugin(BaseIngestionPlugin):
+            def ingest(self, file_path: str) -> pd.DataFrame:
+                return pd.read_csv(file_path)
+
+        df = CsvPlugin().ingest(csv_path)
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_validate_rejects_empty(self):
+        class P(BaseIngestionPlugin):
+            def ingest(self, file_path):
+                return pd.DataFrame()
+
+        with pytest.raises(ValueError, match="empty"):
+            P().validate(pd.DataFrame())
+
+    def test_validate_rejects_none(self):
+        class P(BaseIngestionPlugin):
+            def ingest(self, file_path):
+                return pd.DataFrame({"x": [1]})
+
+        with pytest.raises(ValueError):
+            P().validate(None)
+
+    def test_validate_accepts_valid_dataframe(self):
+        class P(BaseIngestionPlugin):
+            def ingest(self, file_path):
+                return pd.DataFrame({"x": [1]})
+
+        assert P().validate(pd.DataFrame({"x": [1, 2]})) is True
+
+    def test_kwargs_stored(self):
+        class P(BaseIngestionPlugin):
+            def ingest(self, file_path):
+                return pd.DataFrame({"x": [1]})
+
+        p = P(encoding="utf-8", delimiter=",")
+        assert p.kwargs["encoding"] == "utf-8"
+
+    def test_describe_returns_class_name(self):
+        class MyReader(BaseIngestionPlugin):
+            def ingest(self, file_path):
+                return pd.DataFrame({"x": [1]})
+
+        assert "MyReader" in MyReader().describe()
+
+
+# ---------------------------------------------------------------------------
+# Dynamic loading — mirrors the importlib path in main.py
+# ---------------------------------------------------------------------------
+
+class TestPluginDynamicLoading:
+    def test_subclass_discovered_via_importlib(self, tmp_path):
+        """importlib can find a BaseIngestionPlugin subclass in a user file."""
+        code = textwrap.dedent("""
+            import pandas as pd
+            from aidrin.custom_readers.base_ingestion_plugin import BaseIngestionPlugin
+
+            class DynamicReader(BaseIngestionPlugin):
+                def ingest(self, file_path: str) -> pd.DataFrame:
+                    return pd.DataFrame({"loaded": [True]})
+        """)
+        plugin_path = str(tmp_path / "dynamic_reader.py")
+        with open(plugin_path, "w") as f:
+            f.write(code)
+
+        spec = importlib.util.spec_from_file_location("dynamic_reader", plugin_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        plugin_class = next(
+            (
+                getattr(module, n)
+                for n in dir(module)
+                if isinstance(getattr(module, n), type)
+                and issubclass(getattr(module, n), BaseIngestionPlugin)
+                and getattr(module, n) is not BaseIngestionPlugin
+            ),
+            None,
+        )
+        assert plugin_class is not None
+        assert plugin_class.__name__ == "DynamicReader"
+
+    def test_dynamic_ingest_executes_correctly(self, tmp_path):
+        csv_path = str(tmp_path / "data.csv")
+        pd.DataFrame({"val": [10, 20, 30]}).to_csv(csv_path, index=False)
+
+        code = textwrap.dedent("""
+            import pandas as pd
+            from aidrin.custom_readers.base_ingestion_plugin import BaseIngestionPlugin
+
+            class CSVPlugin(BaseIngestionPlugin):
+                def ingest(self, file_path: str) -> pd.DataFrame:
+                    return pd.read_csv(file_path)
+        """)
+        plugin_path = str(tmp_path / "csv_plugin.py")
+        with open(plugin_path, "w") as f:
+            f.write(code)
+
+        spec = importlib.util.spec_from_file_location("csv_plugin", plugin_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        cls = getattr(module, "CSVPlugin")
+        df = cls().ingest(csv_path)
+        assert len(df) == 3
+        assert "val" in df.columns

--- a/test_zarr_reader.py
+++ b/test_zarr_reader.py
@@ -1,0 +1,232 @@
+"""
+Tests for zarrReader.
+
+Covers the three-method contract (read / parse / filter) and the core
+fill-value classification mechanism (_collect_fill_values).
+
+Follows the conventions established in test_hdf5_reader.py:
+- Root-level test file
+- pkg_resources compatibility shim
+- pytest tmp_path fixture
+- caplog assertions for WARNING/INFO log messages
+"""
+
+import logging
+import os
+import sys
+import types
+
+# Compatibility shim — see test_hdf5_reader.py for explanation.
+if "pkg_resources" not in sys.modules:
+    _pkg_resources = types.ModuleType("pkg_resources")
+
+    class _Dist:
+        def __init__(self):
+            self.version = "0.0.0"
+
+    _pkg_resources.get_distribution = lambda _name: _Dist()
+    sys.modules["pkg_resources"] = _pkg_resources
+
+import numpy as np
+import pytest
+
+zarr = pytest.importorskip("zarr", reason="zarr is required for zarrReader tests")
+
+from aidrin.file_handling.readers.zarr_reader import zarrReader
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_zarr_reader")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_dir_store(path, arrays: dict, fill_values: dict = None):
+    """Create a Zarr directory store with the given named arrays."""
+    root = zarr.open_group(str(path), mode="w")
+    for name, data in arrays.items():
+        fv = (fill_values or {}).get(name)
+        kwargs = {} if fv is None else {"fill_value": fv}
+        root.create_dataset(name, data=data, **kwargs)
+    return str(path)
+
+
+def _make_zip_store(zip_path, arrays: dict):
+    """Create a Zarr zip store with the given named arrays."""
+    store = zarr.ZipStore(str(zip_path), mode="w")
+    root = zarr.open_group(store, mode="w")
+    for name, data in arrays.items():
+        root.create_dataset(name, data=data)
+    store.close()
+    return str(zip_path)
+
+
+# ---------------------------------------------------------------------------
+# read()
+# ---------------------------------------------------------------------------
+
+class TestZarrRead:
+    def test_directory_store_returns_dataframe(self, tmp_path, logger):
+        path = _make_dir_store(
+            tmp_path / "s.zarr", {"x": np.array([1.0, 2.0, 3.0])}
+        )
+        df = zarrReader(path, logger).read()
+        assert df is not None
+        assert not df.empty
+
+    def test_zip_store_returns_dataframe(self, tmp_path, logger):
+        path = _make_zip_store(
+            tmp_path / "s.zarr.zip", {"x": np.array([10, 20, 30], dtype=np.int32)}
+        )
+        df = zarrReader(path, logger).read()
+        assert df is not None
+        assert not df.empty
+
+    def test_column_names_are_strings(self, tmp_path, logger):
+        path = _make_dir_store(
+            tmp_path / "s.zarr", {"m": np.array([[1, 2], [3, 4]], dtype=np.int32)}
+        )
+        df = zarrReader(path, logger).read()
+        assert df is not None
+        assert all(isinstance(c, str) for c in df.columns)
+
+    def test_non_numeric_array_skipped(self, tmp_path, logger):
+        store_path = str(tmp_path / "s.zarr")
+        root = zarr.open_group(store_path, mode="w")
+        root.create_dataset("labels", data=np.array(["a", "b", "c"]))
+        root.create_dataset("values", data=np.array([1.0, 2.0, 3.0]))
+        df = zarrReader(store_path, logger).read()
+        assert df is not None
+        assert not df.empty
+
+    def test_empty_store_returns_none(self, tmp_path, logger):
+        zarr.open_group(str(tmp_path / "empty.zarr"), mode="w")
+        df = zarrReader(str(tmp_path / "empty.zarr"), logger).read()
+        assert df is None
+
+    def test_invalid_path_returns_none(self, tmp_path, logger):
+        df = zarrReader(str(tmp_path / "does_not_exist.zarr"), logger).read()
+        assert df is None
+
+
+# ---------------------------------------------------------------------------
+# _collect_fill_values() — the core mechanism
+# ---------------------------------------------------------------------------
+
+class TestFillValueClassification:
+    """The explicit/uncertain split is the central mechanism this PoC demonstrates.
+
+    Non-zero metadata fill_value → explicit (replaced silently).
+    Default zero fill_value     → uncertain (WARNING emitted before replacement).
+    User-supplied fill_values   → always explicit (replaced silently).
+    """
+
+    def test_nonzero_fill_replaced_silently(self, tmp_path, logger, caplog):
+        data = np.array([1.0, -9999.0, 3.0], dtype=np.float64)
+        path = _make_dir_store(
+            tmp_path / "s.zarr", {"d": data}, fill_values={"d": -9999.0}
+        )
+        with caplog.at_level(logging.WARNING):
+            df = zarrReader(path, logger).read()
+        assert df is not None
+        assert df.iloc[:, 0].isna().sum() == 1
+        # No warning: the non-zero sentinel is unambiguously explicit
+        assert not any("default fill value" in r.message for r in caplog.records)
+
+    def test_zero_default_fill_emits_warning(self, tmp_path, logger, caplog):
+        data = np.array([0, 1, 2, 0, 4], dtype=np.int32)
+        path = _make_dir_store(tmp_path / "s.zarr", {"d": data})
+        with caplog.at_level(logging.WARNING):
+            zarrReader(path, logger).read()
+        assert any("default fill value" in r.message for r in caplog.records)
+
+    def test_user_supplied_fill_replaces_silently(self, tmp_path, logger, caplog):
+        data = np.array([1.0, 42.0, 3.0], dtype=np.float64)
+        path = _make_dir_store(tmp_path / "s.zarr", {"d": data})
+        with caplog.at_level(logging.WARNING):
+            df = zarrReader(path, logger, fill_values=[42.0]).read()
+        assert df is not None
+        assert df.iloc[:, 0].isna().sum() == 1
+        assert not any("default fill value" in r.message for r in caplog.records)
+
+    def test_completeness_reflects_fill_replacement(self, tmp_path, logger):
+        """After replacement, completeness computed from the DataFrame is correct."""
+        data = np.array([1.0, -9999.0, 3.0, -9999.0, 5.0], dtype=np.float64)
+        path = _make_dir_store(
+            tmp_path / "s.zarr", {"d": data}, fill_values={"d": -9999.0}
+        )
+        df = zarrReader(path, logger).read()
+        completeness = 1 - df.iloc[:, 0].isnull().mean()
+        assert abs(completeness - 0.6) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# parse()
+# ---------------------------------------------------------------------------
+
+class TestZarrParse:
+    def test_returns_group_names(self, tmp_path, logger):
+        store_path = str(tmp_path / "s.zarr")
+        root = zarr.open_group(store_path, mode="w")
+        root.create_group("group_a")
+        root["group_a"].create_group("sub")
+        root.create_dataset("arr", data=np.array([1.0]))
+        groups = zarrReader(store_path, logger).parse()
+        assert groups is not None
+        assert "group_a" in groups
+
+    def test_excludes_arrays(self, tmp_path, logger):
+        store_path = str(tmp_path / "s.zarr")
+        root = zarr.open_group(store_path, mode="w")
+        root.create_dataset("only_array", data=np.array([1.0, 2.0]))
+        groups = zarrReader(store_path, logger).parse()
+        # Arrays are not groups — list should be empty (not None)
+        assert groups is not None
+        assert "only_array" not in groups
+
+    def test_invalid_path_returns_none(self, tmp_path, logger):
+        result = zarrReader(str(tmp_path / "nope.zarr"), logger).parse()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# filter()
+# ---------------------------------------------------------------------------
+
+class TestZarrFilter:
+    def test_filter_writes_new_zip(self, tmp_path, logger):
+        store_path = str(tmp_path / "s.zarr")
+        root = zarr.open_group(store_path, mode="w")
+        ga = root.create_group("group_a")
+        ga.create_dataset("x", data=np.array([1.0, 2.0]))
+        root.create_group("group_b")
+
+        upload_folder = str(tmp_path / "uploads")
+        os.makedirs(upload_folder)
+
+        result = zarrReader(store_path, logger).filter(
+            ["group_a"],
+            upload_folder=upload_folder,
+            filename="test.zarr.zip",
+        )
+        assert result is not None
+        assert os.path.exists(result)
+
+    def test_filter_comma_string_accepted(self, tmp_path, logger):
+        store_path = str(tmp_path / "s.zarr")
+        root = zarr.open_group(store_path, mode="w")
+        root.create_group("g1")
+        root.create_group("g2")
+
+        upload_folder = str(tmp_path / "uploads")
+        os.makedirs(upload_folder)
+
+        result = zarrReader(store_path, logger).filter(
+            "g1, g2",
+            upload_folder=upload_folder,
+            filename="test.zarr.zip",
+        )
+        assert result is not None


### PR DESCRIPTION
<hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">GSoC 2026 PoC — Multiple File Formats Support (Zarr + Custom Ingestion Plugin)</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Hey, I'm Aman Kumar and I'm applying for the GSoC 2026 project on adding multiple file format support to AIDRIN. This PR is a proof-of-concept submission to show that I've understood the codebase architecture and have a concrete approach to the implementation.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">What I did before writing any code</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Before touching anything, I spent time reading through the existing readers end-to-end —<span class="Apple-converted-space"> </span><code>csv_reader.py</code>,<span class="Apple-converted-space"> </span><code>npz_reader.py</code>,<span class="Apple-converted-space"> </span><code>json_reader.py</code>, and especially<span class="Apple-converted-space"> </span><code>hdf5_reader.py</code><span class="Apple-converted-space"> </span>which is the most sophisticated one. I also traced the full request path: how<span class="Apple-converted-space"> </span><code>file_parser.py</code><span class="Apple-converted-space"> </span>dispatches via<span class="Apple-converted-space"> </span><code>READER_MAP</code>, how<span class="Apple-converted-space"> </span><code>read_file()</code><span class="Apple-converted-space"> </span>/<span class="Apple-converted-space"> </span><code>parse_file()</code><span class="Apple-converted-space"> </span>/<span class="Apple-converted-space"> </span><code>filter_file()</code><span class="Apple-converted-space"> </span>call into the reader, how the result flows into Celery tasks in<span class="Apple-converted-space"> </span><code>main.py</code>, and how the<span class="Apple-converted-space"> </span><code>customMetrics</code><span class="Apple-converted-space"> </span>/<span class="Apple-converted-space"> </span><code>BaseDRAgent</code><span class="Apple-converted-space"> </span>plugin system works. That last part was important because one of the four deliverables (the custom ingestion plugin system) is essentially the same pattern applied to the input side of the pipeline instead of the output side.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">What this PoC contains</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>1.<span class="Apple-converted-space"> </span><code>zarrReader</code><span class="Apple-converted-space"> </span>(<code>aidrin/file_handling/readers/zarr_reader.py</code>)</strong></p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">A complete implementation of the<span class="Apple-converted-space"> </span><code>BaseFileReader</code><span class="Apple-converted-space"> </span>contract for Zarr v2 stores:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li><code>read()</code><span class="Apple-converted-space"> </span>— opens the store (auto-detecting zip vs. directory), does a depth-first traversal via<span class="Apple-converted-space"> </span><code>visititems()</code>, collects rows from all numeric arrays, and returns a flat<span class="Apple-converted-space"> </span><code>pd.DataFrame</code>. Non-numeric dtypes are skipped with an<span class="Apple-converted-space"> </span><code>INFO</code><span class="Apple-converted-space"> </span>log, same as the HDF5 reader handles unsupported types.</li><li><code>parse()</code><span class="Apple-converted-space"> </span>— returns a flat list of group path strings, which is what the key-selector UI expects. Arrays are excluded, only<span class="Apple-converted-space"> </span><code>zarr.Group</code><span class="Apple-converted-space"> </span>objects are listed — this mirrors<span class="Apple-converted-space"> </span><code>hdf5Reader.parse()</code><span class="Apple-converted-space"> </span>which lists HDF5 groups, not datasets.</li><li><code>filter()</code><span class="Apple-converted-space"> </span>— writes a new zip store to<span class="Apple-converted-space"> </span><code>UPLOAD_FOLDER</code><span class="Apple-converted-space"> </span>containing only the selected groups. The output is a<span class="Apple-converted-space"> </span><code>.zarr.zip</code><span class="Apple-converted-space"> </span>file. I made<span class="Apple-converted-space"> </span><code>upload_folder</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code>filename</code><span class="Apple-converted-space"> </span>optional constructor parameters (falling back to<span class="Apple-converted-space"> </span><code>current_app</code><span class="Apple-converted-space"> </span>/<span class="Apple-converted-space"> </span><code>session</code>) specifically so the method is testable without needing a full Flask app context — something I noticed makes the existing<span class="Apple-converted-space"> </span><code>hdf5Reader.filter()</code><span class="Apple-converted-space"> </span>harder to test directly.</li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Registration is a two-liner in<span class="Apple-converted-space"> </span><code>file_parser.py</code><span class="Apple-converted-space"> </span>— that's all it takes for the entire pipeline to pick it up.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>The core mechanism — fill-value sentinel classification</strong></p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">The most non-trivial part of the reader is<span class="Apple-converted-space"> </span><code>_collect_fill_values()</code>. Zarr arrays always store a<span class="Apple-converted-space"> </span><code>fill_value</code><span class="Apple-converted-space"> </span>in their<span class="Apple-converted-space"> </span><code>.zarray</code><span class="Apple-converted-space"> </span>metadata, but the spec says the default is<span class="Apple-converted-space"> </span><code>0</code><span class="Apple-converted-space"> </span>when the producer hasn't set one explicitly. That's a problem: if you have a temperature dataset where<span class="Apple-converted-space"> </span><code>0.0</code><span class="Apple-converted-space"> </span>is a real measurement, you absolutely do not want it silently replaced with<span class="Apple-converted-space"> </span><code>NaN</code><span class="Apple-converted-space"> </span>and then reported as a missing value by the completeness metric.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">I looked at how<span class="Apple-converted-space"> </span><code>hdf5Reader</code><span class="Apple-converted-space"> </span>handles this same ambiguity — HDF5 has the same issue where the native<span class="Apple-converted-space"> </span><code>dataset.fillvalue</code>defaults to the dtype zero when no fill value was explicitly assigned. It uses an explicit/uncertain split:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li><code>explicit</code><span class="Apple-converted-space"> </span>— non-zero fill values, or user-supplied values via the constructor → replaced silently with<span class="Apple-converted-space"> </span><code>NaN</code></li><li><code>uncertain</code><span class="Apple-converted-space"> </span>— the Zarr/HDF5 default zero → a<span class="Apple-converted-space"> </span><code>WARNING</code><span class="Apple-converted-space"> </span>is emitted before replacement, telling the user exactly how many values will be affected and how to suppress it</li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">I replicated that exact pattern for Zarr. The result is that completeness metrics computed downstream are trustworthy — the PoC includes a test (<code>test_completeness_reflects_fill_replacement</code>) that verifies this end-to-end: insert sentinels, read through the reader, check that<span class="Apple-converted-space"> </span><code>1 - df.isnull().mean()</code><span class="Apple-converted-space"> </span>matches the expected completeness ratio.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>2.<span class="Apple-converted-space"> </span><code>BaseIngestionPlugin</code><span class="Apple-converted-space"> </span>(<code>aidrin/custom_readers/base_ingestion_plugin.py</code>)</strong></p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">An abstract base class for user-defined custom ingestion plugins. The idea is: a user writes a class that subclasses<span class="Apple-converted-space"> </span><code>BaseIngestionPlugin</code>, implements<span class="Apple-converted-space"> </span><code>ingest(file_path) -&gt; pd.DataFrame</code>, and uploads it via a CodeMirror editor (same as the existing custom metrics editor). AIDRIN dynamically loads it with<span class="Apple-converted-space"> </span><code>importlib.util</code>, calls<span class="Apple-converted-space"> </span><code>ingest()</code><span class="Apple-converted-space"> </span>on the uploaded file, validates the result with<span class="Apple-converted-space"> </span><code>validate()</code>, and feeds the DataFrame into the standard metric pipeline. No core code changes required to support a new, completely unknown file format.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">The structural parallel to<span class="Apple-converted-space"> </span><code>BaseDRAgent</code><span class="Apple-converted-space"> </span>is intentional and direct:</p>
Custom metrics | Custom ingestion
-- | --
BaseDRAgent | BaseIngestionPlugin
metric(dataset) -> dict | ingest(file_path) -> DataFrame
customMetrics.html editor | customReader.html editor (planned)
CUSTOM_METRICS_FOLDER | CUSTOM_READERS_FOLDER
importlib dynamic load | same

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">I also added<span class="Apple-converted-space"> </span><code>validate()</code><span class="Apple-converted-space"> </span>on the base class (non-abstract, with a default implementation) so the loader can always call it safely regardless of whether the user overrides it, and<span class="Apple-converted-space"> </span><code>describe()</code><span class="Apple-converted-space"> </span>for logging — both follow the same pattern<span class="Apple-converted-space"> </span><code>BaseDRAgent</code><span class="Apple-converted-space"> </span>uses for<span class="Apple-converted-space"> </span><code>kwargs</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code>__init__</code>.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>3. Tests</strong></p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li><code>test_zarr_reader.py</code><span class="Apple-converted-space"> </span>— 14 tests across<span class="Apple-converted-space"> </span><code>TestZarrRead</code>,<span class="Apple-converted-space"> </span><code>TestFillValueClassification</code>,<span class="Apple-converted-space"> </span><code>TestZarrParse</code>,<span class="Apple-converted-space"> </span><code>TestZarrFilter</code></li><li><code>test_custom_reader.py</code><span class="Apple-converted-space"> </span>— 10 tests across<span class="Apple-converted-space"> </span><code>TestBaseIngestionPlugin</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code>TestPluginDynamicLoading</code></li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">All 24 pass. I followed the exact conventions from<span class="Apple-converted-space"> </span><code>test_hdf5_reader.py</code>: root-level test files, the<span class="Apple-converted-space"> </span><code>pkg_resources</code><span class="Apple-converted-space"> </span>compatibility shim, pytest with<span class="Apple-converted-space"> </span><code>tmp_path</code><span class="Apple-converted-space"> </span>and<span class="Apple-converted-space"> </span><code>caplog</code><span class="Apple-converted-space"> </span>fixtures, helper functions for creating test stores,<span class="Apple-converted-space"> </span><code>caplog.at_level(logging.WARNING)</code>assertions for the fill-value warning behaviour.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">What this PoC deliberately does NOT include</h3><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li>ROOT reader (<code>uproot</code>) — not included here since it needs<span class="Apple-converted-space"> </span><code>uproot</code><span class="Apple-converted-space"> </span>+<span class="Apple-converted-space"> </span><code>awkward-array</code><span class="Apple-converted-space"> </span>and the interesting design question (how<span class="Apple-converted-space"> </span><code>filter()</code><span class="Apple-converted-space"> </span>works when uproot is read-only) deserves mentor discussion before I commit to an approach</li><li>Extended HDF5 features (VDS, SWMR, compound streaming) — those are additive changes to the existing reader; I didn't want to mix them into a PoC PR</li><li>Flask routes and frontend for the custom reader UI — the backend<span class="Apple-converted-space"> </span><code>BaseIngestionPlugin</code><span class="Apple-converted-space"> </span>is the load-bearing piece; the routes mirror existing<span class="Apple-converted-space"> </span><code>customMetrics</code><span class="Apple-converted-space"> </span>routes closely enough that I'm confident in the approach but held them back to keep the PoC focused</li><li>No UI changes, no new Celery tasks, no app factory changes</li></ul><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Dependency change</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><code>zarr&gt;=2.16,&lt;3.0</code><span class="Apple-converted-space"> </span>added to<span class="Apple-converted-space"> </span><code>pyproject.toml</code>. Pinned below<span class="Apple-converted-space"> </span><code>3.0</code><span class="Apple-converted-space"> </span>because zarr-python 3.x has breaking API changes (<code>ZipStore</code><span class="Apple-converted-space"> </span>moved,<span class="Apple-converted-space"> </span><code>open_group</code><span class="Apple-converted-space"> </span>signature changed). A v3 migration would be a follow-on task. Everything else (<code>numpy</code>,<span class="Apple-converted-space"> </span><code>pandas</code>) is already present.</p><hr style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Questions I'd want to discuss with mentors before full implementation</h3><ol style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li>Should the Zarr reader target<span class="Apple-converted-space"> </span><code>zarr-python&gt;=2.16,&lt;3.0</code><span class="Apple-converted-space"> </span>for stability, or go straight to the 3.x API?</li><li>For<span class="Apple-converted-space"> </span><code>rootReader.filter()</code><span class="Apple-converted-space"> </span>— since uproot is read-only, the plan is to serialize filtered branches as NPZ and update<span class="Apple-converted-space"> </span><code>session["uploaded_file_type"]</code>. Is that acceptable or would mentors prefer a different approach?</li><li>For the custom reader UI, should it live as a separate page (new route) or be integrated into the existing upload flow?</li></ol><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Happy to discuss any of this. Thanks for considering my application.</p>