### PR TITLE
migrate AI-enabled explainability feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -24,13 +24,21 @@ jobs:
         channels: conda-forge
         activate-environment: aidrin
 
-    - name: Conda info
-      run: conda info
-
-    - name: Conda list
-      run: conda list
-
-    - name: Install
+    - name: Install package (editable)
+      shell: bash -l {0}
       run: |
-        conda run -n aidrin python --version
-        conda run -n aidrin pip install -e .
+        python --version
+        pip install -e .
+
+    - name: Build sdist and wheel
+      shell: bash -l {0}
+      run: |
+        pip install build
+        python -m build
+
+    - name: Verify wheel installs
+      shell: bash -l {0}
+      run: |
+        pip install dist/*.whl
+        python -c "import aidrin; print('aidrin', aidrin.__version__)"
+        python -c "import web; print('web package OK')"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -22,10 +22,11 @@ jobs:
       - name: Install prettier
         run: npm install prettier
 
-      - name: Run prettier
+      - name: Check CSS formatting
         run: npx prettier --check web/static/css
 
-      - name: Check JavaScript syntax
+      - name: Check JavaScript formatting and syntax
         run: |
+          npx prettier --check web/static/js
           node --check web/static/js/inspector.js
           node --check web/static/js/main.js

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -194,6 +194,72 @@ Stop an endpoint with ``globus-compute-endpoint stop <name>``.
 6. Run metrics as usual — computation happens on the remote endpoint, only results travel back
 
 
+LLM Explanations (Optional)
+============================
+
+AIDRIN supports optional AI-generated explanations of metric results using any
+OpenAI-compatible API (OpenAI, Azure OpenAI, Ollama, vLLM, etc.).
+
+**Installation:**
+
+.. code-block:: bash
+
+   pip install -e ".[llm]"
+
+When the ``openai`` package is not installed, the feature is hidden in the UI
+with zero overhead.
+
+**How it works:**
+
+1. Click the sparkle icon in the top-right toolbar to open the AI settings.
+2. Enter the API base URL, API key, and model name.
+3. Click **Test** to verify the connection. If successful, click **Save**.
+4. From that point on, every metric result will show an "AI Explanation"
+   callout below the results with a short LLM-generated interpretation.
+
+**Configuration details:**
+
+- **API Base URL** — the base URL of the OpenAI-compatible API
+  (default: ``https://api.openai.com/v1``). For Ollama, use
+  ``http://localhost:11434/v1``.
+- **API Key** — your API key. Stored in the server-side Flask session only;
+  never exposed in client-side JavaScript or logs.
+- **Model** — the model identifier (e.g., ``gpt-4o-mini``, ``llama3``,
+  ``claude-3-haiku-20240307``).
+
+**What gets sent to the LLM:**
+
+- The metric name and description (context)
+- The metric scores/values (JSON)
+- The plot image (base64 PNG), if the model supports vision
+
+If the model does not support vision (returns empty with an image), AIDRIN
+automatically retries with text-only input. The model name is displayed in
+the explanation callout for transparency.
+
+**Architecture:**
+
+- ``web/llm.py`` — optional dependency detection and ``explain_metric()``
+- ``web/routes/llm.py`` — Flask routes: ``/llm/configure``, ``/llm/test``,
+  ``/llm/explain``, ``/llm/status``, ``/llm/disconnect``
+- ``web/templates/_components/llm_settings.html`` — settings modal
+- LLM calls happen server-side, after the metric result is rendered;
+  the explanation loads asynchronously without blocking results
+
+**Testing with Ollama (local, no API key needed):**
+
+.. code-block:: bash
+
+   # Install and start Ollama
+   ollama serve
+   ollama pull llama3
+
+   # In AIDRIN settings:
+   # API Base URL: http://localhost:11434/v1
+   # API Key: ollama  (any non-empty string)
+   # Model: llama3
+
+
 Debugging the Web Interface
 ============================
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -46,6 +46,22 @@ Step 2: Set Up the Conda Environment
 
 This installs AIDRIN and its dependencies in editable mode.
 
+**Optional extras:**
+
+.. code-block:: bash
+
+   # AI-generated explanations of metric results (OpenAI-compatible APIs)
+   pip install -e ".[llm]"
+
+   # Remote metric execution via Globus Compute
+   pip install -e ".[globus]"
+
+   # OpenTelemetry tracing
+   pip install -e ".[telemetry]"
+
+   # All optional features
+   pip install -e ".[llm,globus,telemetry]"
+
 Step 3: Install Required Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -257,6 +257,12 @@ To use the AIDRIN web application:
    - A JSON report summarizing the results is available for download.
    - Return to the homepage to select another dimension or upload a new dataset.
 
+5. **AI Explanations (Optional)**:
+   - If the ``openai`` package is installed (``pip install aidrin[llm]``), a sparkle icon appears in the top-right toolbar.
+   - Click it to configure an OpenAI-compatible API endpoint (OpenAI, Ollama, vLLM, etc.).
+   - Once configured, each metric result will include an AI-generated explanation summarizing the key observations and implications for AI/ML.
+   - The model name is shown in each explanation for transparency.
+
 Data Readiness Dimensions and Metrics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ telemetry = [
     "opentelemetry-instrumentation-flask>=0.41b0",
     "opentelemetry-exporter-otlp>=1.20",
 ]
+llm = [
+    "openai>=1.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-flask",

--- a/tests/integration/test_llm.py
+++ b/tests/integration/test_llm.py
@@ -1,0 +1,110 @@
+"""Tests for LLM explanation integration (works with or without openai installed)."""
+
+from web.llm import is_llm_available
+
+# Detect whether the openai package is available
+try:
+    import openai  # noqa: F401
+    _HAS_OPENAI = True
+except ImportError:
+    _HAS_OPENAI = False
+
+
+def test_llm_availability():
+    """is_llm_available reflects whether openai is installed."""
+    assert is_llm_available() == _HAS_OPENAI
+
+
+def test_llm_status_endpoint(client):
+    """GET /llm/status returns availability info."""
+    if not _HAS_OPENAI:
+        # Blueprint not registered when openai is absent
+        response = client.get("/llm/status")
+        assert response.status_code == 404
+    else:
+        response = client.get("/llm/status")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["available"] is True
+        assert data["configured"] is False
+
+
+def test_llm_explain_requires_config(client):
+    """POST /llm/explain without config returns 400."""
+    if not _HAS_OPENAI:
+        return  # blueprint not registered
+    response = client.post("/llm/explain", json={
+        "metric_name": "Completeness",
+        "description": "Test description",
+    })
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "not configured" in data["error"].lower()
+
+
+def test_llm_configure_requires_api_key(client):
+    """POST /llm/configure without api_key returns 400."""
+    if not _HAS_OPENAI:
+        return
+    response = client.post("/llm/configure", json={
+        "api_base": "https://api.openai.com/v1",
+        "model": "gpt-4o-mini",
+    })
+    assert response.status_code == 400
+    assert "api key" in response.get_json()["error"].lower()
+
+
+def test_llm_configure_and_disconnect(client):
+    """Configure and disconnect cycle works."""
+    if not _HAS_OPENAI:
+        return
+    # Configure
+    response = client.post("/llm/configure", json={
+        "api_base": "https://api.openai.com/v1",
+        "api_key": "sk-test-key",
+        "model": "gpt-4o-mini",
+    })
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+
+    # Check status — should be configured
+    response = client.get("/llm/status")
+    data = response.get_json()
+    assert data["configured"] is True
+
+    # Disconnect
+    response = client.post("/llm/disconnect")
+    assert response.status_code == 200
+
+    # Check status again — should not be configured
+    response = client.get("/llm/status")
+    data = response.get_json()
+    assert data["configured"] is False
+
+
+def test_llm_explain_no_body(client):
+    """POST /llm/explain with no JSON body returns 400."""
+    if not _HAS_OPENAI:
+        return
+    # First configure
+    client.post("/llm/configure", json={
+        "api_key": "sk-test",
+        "model": "test",
+    })
+    response = client.post("/llm/explain", data="not json",
+                           content_type="text/plain")
+    assert response.status_code == 400
+
+
+def test_explain_metric_without_openai():
+    """explain_metric raises when openai is not installed."""
+    import pytest
+    from web.llm import explain_metric
+    if _HAS_OPENAI:
+        return  # can't test fallback when openai is installed
+    with pytest.raises(RuntimeError, match="openai package not installed"):
+        explain_metric("test", "base64data", {
+            "api_base": "http://localhost",
+            "api_key": "key",
+            "model": "m",
+        })

--- a/web/llm.py
+++ b/web/llm.py
@@ -1,0 +1,126 @@
+"""Optional LLM integration for AI-generated metric explanations.
+
+If the ``openai`` package is installed (``pip install aidrin[llm]``), users can
+configure an OpenAI-compatible endpoint via the UI to receive AI-generated
+explanations of metric results and visualizations.  When the package is **not**
+installed the feature is hidden — zero overhead, zero behaviour change.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_llm_available = False
+
+try:
+    import openai  # noqa: F401
+    _llm_available = True
+except ImportError:
+    pass
+
+SYSTEM_PROMPT = (
+    "You are a data readiness expert. "
+    "The user will provide a metric description and optionally a plot image. "
+    "Reply with exactly 2-3 sentences: "
+    "(1) summarize the key observations from the metric results, "
+    "(2) state implications for AI/ML usage. "
+    "Be direct and concise. Do not explain your reasoning process."
+)
+
+
+def is_llm_available():
+    """Return True if the ``openai`` package is installed."""
+    return _llm_available
+
+
+def explain_metric(description, base64_image, config):
+    """Call an OpenAI-compatible API with a metric description and plot image.
+
+    Parameters
+    ----------
+    description : str
+        Human-readable description of the metric (e.g. from the ``Description`` key).
+    base64_image : str
+        Base64-encoded PNG of the metric visualization.
+    config : dict
+        Must contain ``api_base``, ``api_key``, and ``model``.
+
+    Returns
+    -------
+    str
+        The LLM-generated explanation.
+
+    Raises
+    ------
+    RuntimeError
+        If the LLM SDK is not installed or the API call fails.
+    """
+    if not _llm_available:
+        raise RuntimeError("openai package not installed")
+
+    client = openai.OpenAI(
+        base_url=config["api_base"],
+        api_key=config["api_key"],
+    )
+
+    system_msg = SYSTEM_PROMPT
+
+    if not description and not base64_image:
+        raise RuntimeError("No description or visualization provided")
+
+    # Build multimodal content (text + image)
+    user_content = []
+    if description:
+        user_content.append({"type": "text", "text": description})
+    if base64_image:
+        image_url = base64_image if base64_image.startswith("data:") else f"data:image/png;base64,{base64_image}"
+        user_content.append({
+            "type": "image_url",
+            "image_url": {"url": image_url},
+        })
+
+    # Try with image first; if the model doesn't support vision it may
+    # return an empty response or raise — fall back to text-only.
+    last_response = None
+    for attempt, content in enumerate([user_content, description]):
+        if not content:
+            continue
+        try:
+            response = client.chat.completions.create(
+                model=config["model"],
+                messages=[
+                    {"role": "system", "content": system_msg},
+                    {"role": "user", "content": content},
+                ],
+                max_tokens=1024,
+                temperature=config.get("temperature", 0.5),
+            )
+            last_response = response
+            logger.debug("LLM response (attempt %d): choices=%s",
+                         attempt, response.choices)
+
+            if response.choices:
+                msg = response.choices[0].message
+                result = (msg.content or "").strip()
+                if result:
+                    if attempt > 0:
+                        logger.info("LLM: vision not supported, used text-only fallback")
+                    return result
+                # Some APIs put the answer in a different field
+                if hasattr(msg, "reasoning_content") and msg.reasoning_content:
+                    return msg.reasoning_content.strip()
+
+        except Exception as e:
+            logger.info("LLM attempt %d failed: %s", attempt, e)
+            if attempt == 0 and description:
+                continue
+            raise
+
+    # Build a diagnostic message
+    diag = ""
+    if last_response:
+        try:
+            diag = f" Raw response: {last_response.model_dump_json()[:500]}"
+        except Exception:
+            diag = f" choices={last_response.choices}"
+    raise RuntimeError(f"Model returned empty content.{diag}")

--- a/web/routes/__init__.py
+++ b/web/routes/__init__.py
@@ -15,3 +15,9 @@ def register_blueprints(app):
     if is_globus_available():
         from web.routes.globus import globus_bp
         app.register_blueprint(globus_bp)
+
+    # LLM explanations — optional, only if openai is installed
+    from web.llm import is_llm_available
+    if is_llm_available():
+        from web.routes.llm import llm_bp
+        app.register_blueprint(llm_bp)

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -106,6 +106,11 @@ def inspector():
     # Check if Globus Compute is available
     from web.globus import is_globus_available
     globus_available = is_globus_available()
+
+    # Check if LLM explanations are available
+    from web.llm import is_llm_available
+    llm_available = is_llm_available()
+    llm_configured = bool(session.get("llm_config", {}).get("api_key"))
     globus_authenticated = session.get("globus_authenticated", False)
 
     # Globus remote file — treat as "uploaded" for sidebar/panels visibility
@@ -135,6 +140,8 @@ def inspector():
             globus_authenticated=globus_authenticated,
             globus_mode=globus_mode,
             globus_endpoint_id=globus_endpoint_id,
+            llm_available=llm_available,
+            llm_configured=llm_configured,
         )
     except Exception as e:
         file_upload_time_log.error("Error rendering workspace: %s", e, exc_info=True)
@@ -268,6 +275,28 @@ def clear_cache():
         )
     except Exception as e:
         return jsonify({"success": False, "message": f"Error clearing cache: {str(e)}"}), 500
+
+
+@core_bp.route("/cached-result/<metric_name>")
+def cached_result(metric_name):
+    """Return cached metric results for the current user and file, if available."""
+    user_id = get_current_user_id()
+    file_name = (
+        session.get("uploaded_file_name")
+        or session.get("globus_file_name")
+        or ""
+    )
+    if not file_name:
+        return jsonify({"cached": False})
+
+    cache_key = f"user:{user_id}:file:{file_name}:{metric_name}"
+    entry = current_app.TEMP_RESULTS_CACHE.get(cache_key)
+    if entry and entry.get("data"):
+        resp = {"cached": True, "data": entry["data"]}
+        if entry.get("_llm_explanations"):
+            resp["llm_explanations"] = entry["_llm_explanations"]
+        return jsonify(resp)
+    return jsonify({"cached": False})
 
 
 @core_bp.route("/summary-statistics", methods=["GET", "POST"])

--- a/web/routes/llm.py
+++ b/web/routes/llm.py
@@ -1,0 +1,237 @@
+"""Flask routes for LLM-powered metric explanations.
+
+All routes are under the ``/llm`` prefix. The blueprint is only
+registered when the ``openai`` package is installed.
+"""
+
+import logging
+
+from flask import (
+    Blueprint,
+    jsonify,
+    request,
+    session,
+)
+from web.llm import is_llm_available, explain_metric
+
+logger = logging.getLogger(__name__)
+
+llm_bp = Blueprint("llm", __name__, url_prefix="/llm")
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@llm_bp.route("/status")
+def status():
+    """Check if LLM is available and configured."""
+    config = session.get("llm_config")
+    return jsonify({
+        "available": is_llm_available(),
+        "configured": bool(config and config.get("api_key")),
+    })
+
+
+@llm_bp.route("/configure", methods=["POST"])
+def configure():
+    """Store LLM configuration in the session.
+
+    Expects JSON body:
+    {
+        "api_base": "https://api.openai.com/v1",
+        "api_key": "sk-...",
+        "model": "gpt-4o-mini"
+    }
+    """
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No JSON body provided"}), 400
+
+    api_key = (data.get("api_key") or "").strip()
+    if not api_key:
+        return jsonify({"error": "API key is required"}), 400
+
+    try:
+        temperature = float(data.get("temperature") or 0.5)
+    except (TypeError, ValueError):
+        temperature = 0.5
+
+    session["llm_config"] = {
+        "api_base": (data.get("api_base") or "https://api.openai.com/v1").strip(),
+        "api_key": api_key,
+        "model": (data.get("model") or "gpt-4o-mini").strip(),
+        "temperature": max(0.0, min(2.0, temperature)),
+    }
+
+    logger.info("LLM configured: model=%s, base=%s",
+                session["llm_config"]["model"],
+                session["llm_config"]["api_base"])
+    return jsonify({"success": True})
+
+
+@llm_bp.route("/disconnect", methods=["POST"])
+def disconnect():
+    """Clear LLM configuration from the session."""
+    session.pop("llm_config", None)
+    return jsonify({"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Test connection
+# ---------------------------------------------------------------------------
+
+
+@llm_bp.route("/test", methods=["POST"])
+def test_connection():
+    """Test the LLM connection with a simple prompt.
+
+    Expects JSON body with api_base, api_key, model.
+    Does NOT save to session — just verifies the credentials work.
+    """
+    if not is_llm_available():
+        return jsonify({"error": "openai package not installed"}), 400
+
+    data = request.get_json()
+    if not data or not data.get("api_key"):
+        return jsonify({"error": "API key is required"}), 400
+
+    try:
+        import openai
+        client = openai.OpenAI(
+            base_url=(data.get("api_base") or "https://api.openai.com/v1").strip(),
+            api_key=data["api_key"].strip(),
+        )
+        try:
+            temp = float(data.get("temperature") or 0.5)
+        except (TypeError, ValueError):
+            temp = 0.5
+        response = client.chat.completions.create(
+            model=(data.get("model") or "gpt-4o-mini").strip(),
+            messages=[{"role": "user", "content": "Reply with OK."}],
+            max_tokens=5,
+            temperature=max(0.0, min(2.0, temp)),
+        )
+        reply = (response.choices[0].message.content or "").strip()
+        logger.info("LLM test connection successful: %s", reply)
+        return jsonify({"success": True, "reply": reply})
+    except Exception as e:
+        logger.warning("LLM test connection failed: %s", e)
+        return jsonify({"error": str(e)}), 400
+
+
+# ---------------------------------------------------------------------------
+# Explanation
+# ---------------------------------------------------------------------------
+
+
+@llm_bp.route("/explain", methods=["POST"])
+def explain():
+    """Generate an AI explanation for a metric result.
+
+    Expects JSON body:
+    {
+        "metric_name": "Completeness",
+        "description": "Indicates the proportion of available data...",
+        "visualization": "<base64 PNG or data: URI>"
+    }
+    """
+    config = session.get("llm_config")
+    if not config or not config.get("api_key"):
+        return jsonify({"error": "LLM not configured"}), 400
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No JSON body provided"}), 400
+
+    description = data.get("description") or ""
+    visualization = data.get("visualization") or ""
+    metric_name = data.get("metric_name") or ""
+    scores = data.get("scores")
+
+    if not description and not visualization:
+        return jsonify({"error": "At least description or visualization is required"}), 400
+
+    # Build context: metric name + description + scores
+    parts = []
+    if metric_name:
+        parts.append(f"Metric: {metric_name}.")
+    if description:
+        parts.append(description)
+    if scores:
+        import json
+        scores_str = json.dumps(scores, indent=2, default=str)
+        # Truncate if very large
+        if len(scores_str) > 3000:
+            scores_str = scores_str[:3000] + "\n... (truncated)"
+        parts.append(f"Results:\n{scores_str}")
+    full_description = " ".join(parts) if not scores else "\n\n".join(parts)
+
+    try:
+        explanation = explain_metric(full_description, visualization, config)
+    except Exception as e:
+        logger.error("LLM explain error: %s", e)
+        return jsonify({"error": str(e)}), 500
+
+    if not explanation:
+        return jsonify({"error": "LLM returned an empty response"}), 500
+
+    return jsonify({"explanation": explanation, "model": config.get("model", "")})
+
+
+# ---------------------------------------------------------------------------
+# Cache explanation
+# ---------------------------------------------------------------------------
+
+
+@llm_bp.route("/cache-explanation", methods=["POST"])
+def cache_explanation():
+    """Store an LLM explanation in the user-scoped metric cache entry.
+
+    Expects JSON body:
+    {
+        "metric_name": "data_quality",
+        "result_type": "Completeness",
+        "explanation": "The dataset shows...",
+        "model": "gpt-4o-mini"
+    }
+    """
+    from web.routes.utils import get_current_user_id
+    from flask import current_app
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No JSON body provided"}), 400
+
+    metric_name = data.get("metric_name") or ""
+    result_type = data.get("result_type") or ""
+    explanation = data.get("explanation") or ""
+    model = data.get("model") or ""
+
+    if not metric_name or not explanation:
+        return jsonify({"error": "metric_name and explanation are required"}), 400
+
+    user_id = get_current_user_id()
+    file_name = (
+        session.get("uploaded_file_name")
+        or session.get("globus_file_name")
+        or ""
+    )
+    if not file_name:
+        return jsonify({"error": "No file in session"}), 400
+
+    cache_key = f"user:{user_id}:file:{file_name}:{metric_name}"
+    entry = current_app.TEMP_RESULTS_CACHE.get(cache_key)
+    if not entry:
+        return jsonify({"error": "No cached entry found"}), 404
+
+    # Store explanations keyed by result type (e.g., "Completeness", "Outliers")
+    if "_llm_explanations" not in entry:
+        entry["_llm_explanations"] = {}
+    entry["_llm_explanations"][result_type] = {
+        "explanation": explanation,
+        "model": model,
+    }
+
+    return jsonify({"success": True})

--- a/web/routes/metrics.py
+++ b/web/routes/metrics.py
@@ -331,6 +331,11 @@ def feature_relevance():
                 if col.strip()
             ]
             target = request.form.get("target for feature relevance")
+            if not target:
+                return jsonify({
+                    "trigger": "correlationError",
+                    "error": "Please select a target feature before submitting.",
+                }), 200
             metric_time_log.info(
                 "Feature Relevance request started: %d categorical, %d numerical columns, target=%r",
                 len(cat_cols), len(num_cols), target,

--- a/web/routes/utils.py
+++ b/web/routes/utils.py
@@ -112,6 +112,17 @@ def store_result(metric, final_dict):
     formatted_final_dict = ensure_json_serializable(format_dict_values(final_dict))
     results_id = uuid.uuid4().hex
     current_app.TEMP_RESULTS_CACHE[results_id] = {"data": formatted_final_dict}
+
+    # Also store a persistent user-scoped copy for the cache info page
+    user_id = get_current_user_id()
+    metric_short = metric.rsplit(".", 1)[-1] if "." in metric else metric
+    file_name = session.get("uploaded_file_name") or session.get("globus_file_name") or "unknown"
+    user_key = f"user:{user_id}:file:{file_name}:{metric_short}"
+    current_app.TEMP_RESULTS_CACHE[user_key] = {
+        "data": formatted_final_dict,
+        "timestamp": time.time(),
+    }
+
     return redirect(
         url_for(metric, results_id=results_id, return_type=request.args.get("return_type"))
     )

--- a/web/static/js/inspector.js
+++ b/web/static/js/inspector.js
@@ -7,7 +7,7 @@
 
 // ==================== Panel Switching ====================
 
-let activePanel = 'data-overview';
+let activePanel = "data-overview";
 let codeMirrorEditor = null;
 let lastMetricResult = null; // Store last result for JSON download
 
@@ -21,59 +21,185 @@ function showPanel(panelId, pushHistory) {
   if (pushHistory === undefined) pushHistory = true;
 
   // Validate the panel exists, fall back to data-overview
-  const panel = document.getElementById('panel-' + panelId);
-  if (!panel) panelId = 'data-overview';
-  const validPanel = document.getElementById('panel-' + panelId);
+  const panel = document.getElementById("panel-" + panelId);
+  if (!panel) panelId = "data-overview";
+  const validPanel = document.getElementById("panel-" + panelId);
 
   // Hide all panels
-  document.querySelectorAll('.metric-panel').forEach(p => {
-    p.classList.add('hidden');
+  document.querySelectorAll(".metric-panel").forEach((p) => {
+    p.classList.add("hidden");
   });
 
   // Show the selected panel
   if (validPanel) {
-    validPanel.classList.remove('hidden');
+    validPanel.classList.remove("hidden");
     activePanel = panelId;
   }
 
   // Hide results from previous metric and reset
-  const resultsSection = document.getElementById('results-section');
-  if (resultsSection) resultsSection.style.display = 'none';
-  const metricsDiv = document.getElementById('metrics');
-  if (metricsDiv) metricsDiv.innerHTML = '';
-  const buttonsContainer = document.getElementById('buttonsContainer');
-  if (buttonsContainer) buttonsContainer.style.display = 'none';
+  const resultsSection = document.getElementById("results-section");
+  if (resultsSection) resultsSection.style.display = "none";
+  const metricsDiv = document.getElementById("metrics");
+  if (metricsDiv) metricsDiv.innerHTML = "";
+  const buttonsContainer = document.getElementById("buttonsContainer");
+  if (buttonsContainer) buttonsContainer.style.display = "none";
+
+  // Check for cached results and restore them
+  _restoreCachedResult(panelId);
 
   // Highlight active sidebar item
-  document.querySelectorAll('.sidebar-metric-item').forEach(btn => {
-    btn.classList.remove('bg-black/10', 'dark:bg-white/10', 'font-semibold');
+  document.querySelectorAll(".sidebar-metric-item").forEach((btn) => {
+    btn.classList.remove("bg-black/10", "dark:bg-white/10", "font-semibold");
   });
 
   // Update URL hash and browser history
-  if (pushHistory && location.hash !== '#' + panelId) {
-    history.pushState({ panel: panelId }, '', '#' + panelId);
+  if (pushHistory && location.hash !== "#" + panelId) {
+    history.pushState({ panel: panelId }, "", "#" + panelId);
   }
 
   // Lazy init CodeMirror for custom metrics
-  if (panelId === 'custom-metrics' && !codeMirrorEditor) {
+  if (panelId === "custom-metrics" && !codeMirrorEditor) {
     initCodeMirror();
   }
 
   // Close mobile sidebar after selection
-  const sidebar = document.getElementById('sidebar');
+  const sidebar = document.getElementById("sidebar");
   if (sidebar && window.innerWidth < 640) {
-    sidebar.classList.add('-translate-x-full');
+    sidebar.classList.add("-translate-x-full");
+  }
+}
+
+// Panel ID → backend cache metric name mapping
+const _panelCacheMap = {
+  "data-quality": "data_quality",
+  fairness: "fairness",
+  "correlation-analysis": "correlation_analysis",
+  "feature-relevance": "feature_relevance",
+  "class-imbalance": "class_imbalance",
+  "privacy-preservation": "privacy_preservation",
+  "hipaa-compliance": "hipaa_compliance",
+};
+
+/**
+ * Check if there are cached results for the given panel and display them.
+ */
+function _restoreCachedResult(panelId) {
+  const metricName = _panelCacheMap[panelId];
+  if (!metricName) return; // no caching for data-overview, fair-assessment, custom-metrics
+
+  // Restore form state from sessionStorage
+  const savedForm = sessionStorage.getItem("aidrin_form_" + panelId);
+  if (savedForm) {
+    try {
+      _restoreFormState(panelId, JSON.parse(savedForm));
+    } catch (e) {
+      debugLog("Form restore error:", e);
+    }
+  }
+
+  fetch("/cached-result/" + metricName)
+    .then((r) => r.json())
+    .then((resp) => {
+      if (resp.cached && resp.data && activePanel === panelId) {
+        lastMetricResult = resp.data;
+        const resultsSection = document.getElementById("results-section");
+        if (resultsSection) resultsSection.style.display = "block";
+        const hasLLMCache =
+          resp.llm_explanations &&
+          Object.keys(resp.llm_explanations).length > 0;
+        renderWorkspaceResults(resp.data, { skipLLM: hasLLMCache });
+
+        // Restore cached LLM explanations instead of re-calling the LLM
+        if (hasLLMCache) {
+          setTimeout(() => {
+            _restoreLLMExplanations(resp.llm_explanations);
+          }, 200);
+        }
+      }
+    })
+    .catch((err) => debugLog("Cache restore error:", err));
+}
+
+/**
+ * Restore cached LLM explanations into already-rendered result cards.
+ * Finds LLM placeholder divs and fills them with the cached text,
+ * preventing duplicate LLM API calls.
+ */
+function _restoreLLMExplanations(explanations) {
+  // Find all LLM placeholder containers in the results
+  const containers = document.querySelectorAll('[id^="llm-"]');
+  containers.forEach((container) => {
+    // The container was placed after a result card whose type is in the heading
+    const card = container.closest(
+      ".p-5.mb-4.bg-white, .p-5.mb-4.dark\\:bg-gray-800",
+    );
+    if (!card) return;
+    const heading = card.querySelector("h3");
+    if (!heading) return;
+    const resultType = heading.textContent.trim();
+
+    if (explanations[resultType]) {
+      const cached = explanations[resultType];
+      _renderLLMCallout(container, cached.explanation, cached.model);
+    }
+  });
+}
+
+/**
+ * Restore form inputs from a saved state object.
+ */
+function _restoreFormState(panelId, state) {
+  const panel = document.getElementById("panel-" + panelId);
+  if (!panel) return;
+
+  for (const [key, value] of Object.entries(state)) {
+    if (!value) continue;
+
+    // Checkboxes with name matching the key
+    const checkboxes = panel.querySelectorAll(
+      `input[type="checkbox"][name="${key}"]`,
+    );
+    if (checkboxes.length > 0) {
+      const values = Array.isArray(value) ? value : [value];
+      checkboxes.forEach((cb) => {
+        cb.checked = values.includes(cb.value);
+      });
+      continue;
+    }
+
+    // Select dropdowns
+    const select = panel.querySelector(`select[name="${key}"]`);
+    if (select) {
+      // Handle multi-select
+      if (select.multiple) {
+        const values = typeof value === "string" ? value.split(",") : [value];
+        Array.from(select.options).forEach((opt) => {
+          opt.selected = values.includes(opt.value);
+        });
+      } else {
+        select.value = value;
+      }
+      continue;
+    }
+
+    // Text/hidden inputs
+    const input = panel.querySelector(
+      `input[name="${key}"]:not([type="checkbox"])`,
+    );
+    if (input) {
+      input.value = value;
+    }
   }
 }
 
 // Handle browser back/forward buttons
-window.addEventListener('popstate', function (e) {
+window.addEventListener("popstate", function (e) {
   if (e.state && e.state.panel) {
     showPanel(e.state.panel, false);
   } else {
     // Read from hash or fall back to data-overview
-    const hash = location.hash.replace('#', '');
-    showPanel(hash || 'data-overview', false);
+    const hash = location.hash.replace("#", "");
+    showPanel(hash || "data-overview", false);
   }
 });
 
@@ -87,22 +213,22 @@ function toggleSidebarGroup(groupId) {
   const group = document.getElementById(groupId);
   if (!group) return;
 
-  group.classList.toggle('hidden');
+  group.classList.toggle("hidden");
 
   // Rotate arrow
-  const arrow = document.getElementById(groupId + '-arrow');
+  const arrow = document.getElementById(groupId + "-arrow");
   if (arrow) {
-    arrow.classList.toggle('rotate-180');
+    arrow.classList.toggle("rotate-180");
   }
 }
 
 // Mobile sidebar toggle
-document.addEventListener('DOMContentLoaded', function () {
-  const sidebarToggle = document.getElementById('sidebar-toggle');
-  const sidebar = document.getElementById('sidebar');
+document.addEventListener("DOMContentLoaded", function () {
+  const sidebarToggle = document.getElementById("sidebar-toggle");
+  const sidebar = document.getElementById("sidebar");
   if (sidebarToggle && sidebar) {
-    sidebarToggle.addEventListener('click', function () {
-      sidebar.classList.toggle('-translate-x-full');
+    sidebarToggle.addEventListener("click", function () {
+      sidebar.classList.toggle("-translate-x-full");
     });
   }
 });
@@ -116,132 +242,185 @@ document.addEventListener('DOMContentLoaded', function () {
  */
 function workspaceSubmit(targetUrl) {
   // Clear previous results before submitting new ones
-  const resultsSection = document.getElementById('results-section');
-  if (resultsSection) resultsSection.style.display = 'none';
-  const metricsDiv = document.getElementById('metrics');
-  if (metricsDiv) metricsDiv.innerHTML = '';
-  const buttonsContainer = document.getElementById('buttonsContainer');
-  if (buttonsContainer) buttonsContainer.style.display = 'none';
+  const resultsSection = document.getElementById("results-section");
+  if (resultsSection) resultsSection.style.display = "none";
+  const metricsDiv = document.getElementById("metrics");
+  if (metricsDiv) metricsDiv.innerHTML = "";
+  const buttonsContainer = document.getElementById("buttonsContainer");
+  if (buttonsContainer) buttonsContainer.style.display = "none";
 
   // In Globus mode, route through Globus Compute instead of local endpoint
   if (window.AIDRIN_GLOBUS_MODE) {
-    const gPanel = document.getElementById('panel-' + activePanel);
-    const gForm = gPanel ? gPanel.querySelector('form') : null;
+    const gPanel = document.getElementById("panel-" + activePanel);
+    const gForm = gPanel ? gPanel.querySelector("form") : null;
     const gFormData = gForm ? new FormData(gForm) : new FormData();
 
     // Map route URLs to remote_metric_runner metric names
     const urlToMetrics = {
-      '/data-quality': ['completeness', 'outliers', 'duplicates'],
-      '/fairness': ['representation_rate', 'statistical_rates'],
-      '/feature-relevance': ['feature_relevance'],
-      '/correlation-analysis': ['correlations'],
-      '/class-imbalance': ['class_distribution'],
-      '/privacy-preservation': ['k_anonymity', 'l_diversity', 't_closeness', 'entropy_risk'],
-      '/hipaa-compliance': ['hipaa'],
+      "/data-quality": ["completeness", "outliers", "duplicates"],
+      "/fairness": ["representation_rate", "statistical_rates"],
+      "/feature-relevance": ["feature_relevance"],
+      "/correlation-analysis": ["correlations"],
+      "/class-imbalance": ["class_distribution"],
+      "/privacy-preservation": [
+        "k_anonymity",
+        "l_diversity",
+        "t_closeness",
+        "entropy_risk",
+      ],
+      "/hipaa-compliance": ["hipaa"],
     };
 
-    let remoteName = urlToMetrics[targetUrl] ? urlToMetrics[targetUrl][0] : targetUrl.replace('/', '');
+    let remoteName = urlToMetrics[targetUrl]
+      ? urlToMetrics[targetUrl][0]
+      : targetUrl.replace("/", "");
     let remoteParams = {};
-    let remoteDisplayName = '';
+    let remoteDisplayName = "";
 
     // Map metric names to display names
     const metricDisplayMap = {
-      'completeness': 'Completeness', 'outliers': 'Outliers', 'duplicates': 'Duplicity',
-      'representation_rate': 'Representation Rate', 'statistical_rates': 'Statistical Rate',
-      'feature_relevance': 'Feature Relevance', 'correlations': 'Correlation Analysis',
-      'class_distribution': 'Class Imbalance',
-      'k_anonymity': 'k-Anonymity', 'l_diversity': 'l-Diversity',
-      't_closeness': 't-Closeness', 'entropy_risk': 'Entropy Risk',
-      'hipaa': 'HIPAA Compliance',
+      completeness: "Completeness",
+      outliers: "Outliers",
+      duplicates: "Duplicity",
+      representation_rate: "Representation Rate",
+      statistical_rates: "Statistical Rate",
+      feature_relevance: "Feature Relevance",
+      correlations: "Correlation Analysis",
+      class_distribution: "Class Imbalance",
+      k_anonymity: "k-Anonymity",
+      l_diversity: "l-Diversity",
+      t_closeness: "t-Closeness",
+      entropy_risk: "Entropy Risk",
+      hipaa: "HIPAA Compliance",
     };
 
-    if (targetUrl === '/data-quality') {
-      remoteName = 'data_quality';
+    if (targetUrl === "/data-quality") {
+      remoteName = "data_quality";
       const selected = [];
       const selectedNames = [];
-      if (gFormData.get('completeness') === 'yes') { selected.push('completeness'); selectedNames.push('Completeness'); }
-      if (gFormData.get('outliers') === 'yes') { selected.push('outliers'); selectedNames.push('Outliers'); }
-      if (gFormData.get('duplicity') === 'yes') { selected.push('duplicates'); selectedNames.push('Duplicity'); }
+      if (gFormData.get("completeness") === "yes") {
+        selected.push("completeness");
+        selectedNames.push("Completeness");
+      }
+      if (gFormData.get("outliers") === "yes") {
+        selected.push("outliers");
+        selectedNames.push("Outliers");
+      }
+      if (gFormData.get("duplicity") === "yes") {
+        selected.push("duplicates");
+        selectedNames.push("Duplicity");
+      }
       if (selected.length === 0) {
-        if (typeof showToast === 'function') showToast('Please select at least one metric', 'error');
+        if (typeof showToast === "function")
+          showToast("Please select at least one metric", "error");
         return;
       }
       remoteParams = { selected: selected };
-      remoteDisplayName = selectedNames.join(', ');
-    } else if (targetUrl === '/feature-relevance') {
-      remoteName = 'feature_relevance';
-      remoteDisplayName = 'Feature Relevance';
+      remoteDisplayName = selectedNames.join(", ");
+    } else if (targetUrl === "/feature-relevance") {
+      remoteName = "feature_relevance";
+      remoteDisplayName = "Feature Relevance";
       // Collect selected features and target from the form
-      const catCols = Array.from(gFormData.getAll('categorical features for feature relevancy')).join(',');
-      const numCols = Array.from(gFormData.getAll('numerical features for feature relevancy')).join(',');
-      const target = gFormData.get('target for feature relevance');
+      const catCols = Array.from(
+        gFormData.getAll("categorical features for feature relevancy"),
+      ).join(",");
+      const numCols = Array.from(
+        gFormData.getAll("numerical features for feature relevancy"),
+      ).join(",");
+      const target = gFormData.get("target for feature relevance");
       if (!target) {
-        if (typeof showToast === 'function') showToast('Please select a target feature', 'error');
+        if (typeof showToast === "function")
+          showToast("Please select a target feature", "error");
         return;
       }
       remoteParams = {
         target_col: target,
-        cat_cols: catCols ? catCols.split(',') : [],
-        num_cols: numCols ? numCols.split(',') : [],
+        cat_cols: catCols ? catCols.split(",") : [],
+        num_cols: numCols ? numCols.split(",") : [],
       };
-    } else if (targetUrl === '/correlation-analysis') {
-      remoteName = 'correlations';
-      remoteDisplayName = 'Correlation Analysis';
-      const catCols = Array.from(gFormData.getAll('categorical features for correlation analysis')).join(',');
-      const numCols = Array.from(gFormData.getAll('numerical features for correlation analysis')).join(',');
-      const columns = (catCols ? catCols.split(',') : []).concat(numCols ? numCols.split(',') : []);
+    } else if (targetUrl === "/correlation-analysis") {
+      remoteName = "correlations";
+      remoteDisplayName = "Correlation Analysis";
+      const catCols = Array.from(
+        gFormData.getAll("categorical features for correlation analysis"),
+      ).join(",");
+      const numCols = Array.from(
+        gFormData.getAll("numerical features for correlation analysis"),
+      ).join(",");
+      const columns = (catCols ? catCols.split(",") : []).concat(
+        numCols ? numCols.split(",") : [],
+      );
       remoteParams = { columns: columns };
-    } else if (targetUrl === '/fairness') {
-      remoteName = 'fairness';
+    } else if (targetUrl === "/fairness") {
+      remoteName = "fairness";
       const selectedFairness = [];
       const selectedNames = [];
       remoteParams = { selected: [] };
 
-      if (gFormData.get('representation rate') === 'yes') {
-        remoteParams.selected.push('representation_rate');
-        remoteParams.rep_columns = [gFormData.get('features for representation rate')];
-        selectedNames.push('Representation Rate');
+      if (gFormData.get("representation rate") === "yes") {
+        remoteParams.selected.push("representation_rate");
+        remoteParams.rep_columns = [
+          gFormData.get("features for representation rate"),
+        ];
+        selectedNames.push("Representation Rate");
       }
-      if (gFormData.get('statistical rate') === 'yes') {
-        remoteParams.selected.push('statistical_rates');
-        remoteParams.sensitive_attr = gFormData.get('features for statistical rate');
-        remoteParams.y_true = gFormData.get('target for statistical rate');
-        selectedNames.push('Statistical Rate');
+      if (gFormData.get("statistical rate") === "yes") {
+        remoteParams.selected.push("statistical_rates");
+        remoteParams.sensitive_attr = gFormData.get(
+          "features for statistical rate",
+        );
+        remoteParams.y_true = gFormData.get("target for statistical rate");
+        selectedNames.push("Statistical Rate");
       }
       if (remoteParams.selected.length === 0) {
-        if (typeof showToast === 'function') showToast('Please select at least one metric', 'error');
+        if (typeof showToast === "function")
+          showToast("Please select at least one metric", "error");
         return;
       }
-      remoteDisplayName = selectedNames.join(', ');
-    } else if (targetUrl === '/class-imbalance') {
-      remoteName = 'class_distribution';
-      remoteDisplayName = 'Class Imbalance';
-      remoteParams = { column: gFormData.get('target features for class imbalance') };
-    } else if (targetUrl === '/privacy-preservation') {
+      remoteDisplayName = selectedNames.join(", ");
+    } else if (targetUrl === "/class-imbalance") {
+      remoteName = "class_distribution";
+      remoteDisplayName = "Class Imbalance";
+      remoteParams = {
+        column: gFormData.get("target features for class imbalance"),
+      };
+    } else if (targetUrl === "/privacy-preservation") {
       // Privacy has multiple sub-metrics — check which are selected
       // For now, run k-anonymity if selected (most common)
-      if (gFormData.get('k-anonymity') === 'yes') {
-        remoteName = 'k_anonymity';
-        remoteDisplayName = 'k-Anonymity';
-        remoteParams = { quasi_ids: Array.from(gFormData.getAll('quasi identifiers for k-anonymity')) };
-      } else if (gFormData.get('l-diversity') === 'yes') {
-        remoteName = 'l_diversity';
-        remoteDisplayName = 'l-Diversity';
+      if (gFormData.get("k-anonymity") === "yes") {
+        remoteName = "k_anonymity";
+        remoteDisplayName = "k-Anonymity";
         remoteParams = {
-          quasi_ids: Array.from(gFormData.getAll('quasi identifiers for l-diversity')),
-          sensitive_col: gFormData.get('sensitive attribute for l-diversity'),
+          quasi_ids: Array.from(
+            gFormData.getAll("quasi identifiers for k-anonymity"),
+          ),
         };
-      } else if (gFormData.get('t-closeness') === 'yes') {
-        remoteName = 't_closeness';
-        remoteDisplayName = 't-Closeness';
+      } else if (gFormData.get("l-diversity") === "yes") {
+        remoteName = "l_diversity";
+        remoteDisplayName = "l-Diversity";
         remoteParams = {
-          quasi_ids: Array.from(gFormData.getAll('quasi identifiers for t-closeness')),
-          sensitive_col: gFormData.get('sensitive attribute for t-closeness'),
+          quasi_ids: Array.from(
+            gFormData.getAll("quasi identifiers for l-diversity"),
+          ),
+          sensitive_col: gFormData.get("sensitive attribute for l-diversity"),
         };
-      } else if (gFormData.get('entropy risk') === 'yes') {
-        remoteName = 'entropy_risk';
-        remoteDisplayName = 'Entropy Risk';
-        remoteParams = { quasi_ids: Array.from(gFormData.getAll('quasi identifiers for entropy risk')) };
+      } else if (gFormData.get("t-closeness") === "yes") {
+        remoteName = "t_closeness";
+        remoteDisplayName = "t-Closeness";
+        remoteParams = {
+          quasi_ids: Array.from(
+            gFormData.getAll("quasi identifiers for t-closeness"),
+          ),
+          sensitive_col: gFormData.get("sensitive attribute for t-closeness"),
+        };
+      } else if (gFormData.get("entropy risk") === "yes") {
+        remoteName = "entropy_risk";
+        remoteDisplayName = "Entropy Risk";
+        remoteParams = {
+          quasi_ids: Array.from(
+            gFormData.getAll("quasi identifiers for entropy risk"),
+          ),
+        };
       }
     } else {
       remoteDisplayName = metricDisplayMap[remoteName] || remoteName;
@@ -252,10 +431,10 @@ function workspaceSubmit(targetUrl) {
   }
 
   // Local mode: find the active form
-  const panel = document.getElementById('panel-' + activePanel);
+  const panel = document.getElementById("panel-" + activePanel);
   if (!panel) return;
 
-  const form = panel.querySelector('form');
+  const form = panel.querySelector("form");
   if (!form) return;
 
   const formData = new FormData(form);
@@ -264,11 +443,11 @@ function workspaceSubmit(targetUrl) {
   // The backend expects short names for multi-value checkbox fields,
   // but the form uses longer descriptive names. Concatenate and remap.
   const fieldRemaps = {
-    'numerical features for feature relevancy': 'numerical features',
-    'categorical features for feature relevancy': 'categorical features',
-    'numerical features for correlation analysis': 'numerical features',
-    'categorical features for correlation analysis': 'categorical features',
-    'checkboxValues': 'correlation columns',
+    "numerical features for feature relevancy": "numerical features",
+    "categorical features for feature relevancy": "categorical features",
+    "numerical features for correlation analysis": "numerical features",
+    "categorical features for correlation analysis": "categorical features",
+    checkboxValues: "correlation columns",
   };
 
   // Collect multi-value checkbox fields and remap them
@@ -276,7 +455,7 @@ function workspaceSubmit(targetUrl) {
   for (const [longName, shortName] of Object.entries(fieldRemaps)) {
     const values = formData.getAll(longName);
     if (values.length > 0) {
-      collectedMulti[shortName] = values.join(',');
+      collectedMulti[shortName] = values.join(",");
     }
   }
 
@@ -285,7 +464,8 @@ function workspaceSubmit(targetUrl) {
   const remapLongNames = new Set(Object.keys(fieldRemaps));
   for (const [key, value] of formData.entries()) {
     // Skip empty file inputs
-    if (form.querySelector(`input[type="file"][name="${key}"]`) && !value.name) continue;
+    if (form.querySelector(`input[type="file"][name="${key}"]`) && !value.name)
+      continue;
     // Skip fields that will be remapped
     if (remapLongNames.has(key)) continue;
     processedFormData.append(key, value);
@@ -295,10 +475,30 @@ function workspaceSubmit(targetUrl) {
     processedFormData.set(shortName, joined);
   }
 
-  // Show the results section and set loading state
-  if (resultsSection) resultsSection.style.display = 'block';
+  // Save form state for cache restore
+  try {
+    const formState = {};
+    for (const [key, value] of formData.entries()) {
+      if (formState[key]) {
+        // Multi-value: convert to array
+        if (!Array.isArray(formState[key])) formState[key] = [formState[key]];
+        formState[key].push(value);
+      } else {
+        formState[key] = value;
+      }
+    }
+    sessionStorage.setItem(
+      "aidrin_form_" + activePanel,
+      JSON.stringify(formState),
+    );
+  } catch (e) {
+    debugLog("Form state save error:", e);
+  }
 
-  const resultsContainer = document.getElementById('metrics');
+  // Show the results section and set loading state
+  if (resultsSection) resultsSection.style.display = "block";
+
+  const resultsContainer = document.getElementById("metrics");
   if (resultsContainer) {
     resultsContainer.innerHTML = `
       <div class="text-center py-8">
@@ -310,32 +510,34 @@ function workspaceSubmit(targetUrl) {
   }
 
   // POST to the metric endpoint
-  fetch(targetUrl + '?return_type=json', {
-    method: 'POST',
+  fetch(targetUrl + "?return_type=json", {
+    method: "POST",
     body: processedFormData,
   })
-    .then(response => {
+    .then((response) => {
       if (response.ok) {
         return response.json();
       } else {
         throw new Error(`Unexpected response from server (${response.status})`);
       }
     })
-    .then(data => {
+    .then((data) => {
       // Store for download
       lastMetricResult = data;
 
       // Handle special error formats from some endpoints (feature relevance, correlation)
-      if (data.trigger === 'correlationError') {
-        const msg = data.error || 'An error occurred with the analysis';
-        console.error('[inspector] correlationError:', msg);
-        const m = document.getElementById('metrics');
-        if (m) m.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">${msg}</div>`;
+      if (data.trigger === "correlationError") {
+        const msg = data.error || "An error occurred with the analysis";
+        console.error("[inspector] correlationError:", msg);
+        const m = document.getElementById("metrics");
+        if (m)
+          m.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">${msg}</div>`;
         return;
       }
       if (data.message && !data.trigger && Object.keys(data).length <= 2) {
-        const m = document.getElementById('metrics');
-        if (m) m.innerHTML = `<div class="p-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 dark:text-yellow-300" role="alert">${data.message}</div>`;
+        const m = document.getElementById("metrics");
+        if (m)
+          m.innerHTML = `<div class="p-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 dark:text-yellow-300" role="alert">${data.message}</div>`;
         return;
       }
 
@@ -343,10 +545,11 @@ function workspaceSubmit(targetUrl) {
       renderWorkspaceResults(data);
       handleAsyncResults(data);
     })
-    .catch(error => {
-      console.error('Error:', error);
-      const m = document.getElementById('metrics');
-      if (m) m.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">${error.message || String(error)}</div>`;
+    .catch((error) => {
+      console.error("Error:", error);
+      const m = document.getElementById("metrics");
+      if (m)
+        m.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">${error.message || String(error)}</div>`;
     });
 }
 
@@ -355,32 +558,52 @@ function workspaceSubmit(targetUrl) {
  * Left column: visualization image. Right column: description + scores table.
  * Falls back to single column if no visualization.
  */
-function renderWorkspaceResults(data) {
-  const metrics = document.getElementById('metrics');
+function renderWorkspaceResults(data, options) {
+  const skipLLM = options && options.skipLLM;
+  const metrics = document.getElementById("metrics");
   if (!metrics) return;
 
-  let html = '';
+  let html = "";
 
   for (const [type, results] of Object.entries(data)) {
-    if (typeof results !== 'object' || results === null) continue;
+    if (typeof results !== "object" || results === null) continue;
 
     // Skip async tasks — they're handled by handleAsyncResults/pollAsyncMetric
     if (results.is_async && results.task_id) continue;
 
     // Extract parts
-    const description = results.Description || '';
-    const error = results.Error || '';
+    const description = results.Description || "";
+    const error = results.Error || "";
     const visualizations = [];
     const scores = {};
 
     for (const [key, value] of Object.entries(results)) {
-      if (key === 'Description' || key === 'Error' || key === 'Graph interpretation') continue;
-      if (key.toLowerCase().includes('visualization') && typeof value === 'string' && value.length > 100) {
-        visualizations.push({ key, src: value.startsWith('data:') ? value : `data:image/png;base64,${value}` });
+      if (
+        key === "Description" ||
+        key === "Error" ||
+        key === "Graph interpretation"
+      )
+        continue;
+      if (
+        key.toLowerCase().includes("visualization") &&
+        typeof value === "string" &&
+        value.length > 100
+      ) {
+        visualizations.push({
+          key,
+          src: value.startsWith("data:")
+            ? value
+            : `data:image/png;base64,${value}`,
+        });
       } else {
         scores[key] = value;
       }
     }
+
+    // Skip empty result cards (no viz, no scores, no error)
+    const hasViz = visualizations.length > 0;
+    const hasScores = Object.keys(scores).length > 0;
+    if (!hasViz && !hasScores && !error) continue;
 
     // Card wrapper — Flowbite card
     html += `<div class="p-5 mb-4 bg-white border border-gray-200 rounded-lg shadow-sm dark:bg-gray-800 dark:border-gray-700">`;
@@ -396,23 +619,23 @@ function renderWorkspaceResults(data) {
       }
 
       // Graph interpretation — rendered as a distinct callout below the plot/scores
-      const interpretation = results['Graph interpretation'];
+      const interpretation = results["Graph interpretation"];
 
       // Two-column layout: visualization | scores
-      const hasViz = visualizations.length > 0;
-      const hasScores = Object.keys(scores).length > 0;
-      const pairId = 'result-pair-' + Math.random().toString(36).substr(2, 6);
+      const pairId = "result-pair-" + Math.random().toString(36).substr(2, 6);
 
       if (hasViz || hasScores) {
-        html += `<div class="grid gap-4" style="grid-template-columns: ${hasViz && hasScores ? '1fr 1fr' : '1fr'};">`;
+        html += `<div class="grid gap-4" style="grid-template-columns: ${hasViz && hasScores ? "1fr 1fr" : "1fr"};">`;
 
         // Left: visualizations
         if (hasViz) {
           html += `<div class="flex flex-col items-center gap-4">`;
           for (const viz of visualizations) {
             const isHeatmap = /correlation|heatmap/i.test(viz.key);
-            const imgStyle = isHeatmap ? ' style="max-width:500px; max-height:500px; object-fit:contain;"' : '';
-            html += `<img src="${viz.src}" alt="${viz.key}" class="rounded-lg ${isHeatmap ? '' : 'w-full'}"${imgStyle} data-pair="${pairId}" onload="syncScoresHeight('${pairId}')" />`;
+            const imgStyle = isHeatmap
+              ? ' style="max-width:500px; max-height:500px; object-fit:contain;"'
+              : "";
+            html += `<img src="${viz.src}" alt="${viz.key}" class="rounded-lg ${isHeatmap ? "" : "w-full"}"${imgStyle} data-pair="${pairId}" onload="syncScoresHeight('${pairId}')" />`;
           }
           html += `</div>`;
         }
@@ -428,7 +651,11 @@ function renderWorkspaceResults(data) {
       }
 
       // Graph interpretation callout (if present)
-      if (interpretation && typeof interpretation === 'string' && !interpretation.includes('No visualization available')) {
+      if (
+        interpretation &&
+        typeof interpretation === "string" &&
+        !interpretation.includes("No visualization available")
+      ) {
         html += `<div class="flex items-start gap-2.5 p-4 mt-4 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
           <svg class="w-5 h-5 shrink-0 mt-0.5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 011.037-.443 48.282 48.282 0 005.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"/></svg>
           <div>
@@ -438,10 +665,32 @@ function renderWorkspaceResults(data) {
         </div>`;
       }
 
+      // AI Explanation placeholder (filled async if LLM is configured)
+      if (window.AIDRIN_LLM_ENABLED && (hasViz || hasScores)) {
+        const llmId = "llm-" + pairId;
+        html += `<div id="${llmId}" class="mt-3"></div>`;
+        if (!skipLLM) {
+          // Schedule async LLM call after DOM is updated
+          const _llmType = type,
+            _llmDesc = description,
+            _llmViz = [...visualizations],
+            _llmScores = { ...scores };
+          setTimeout(() => {
+            requestLLMExplanation(
+              llmId,
+              _llmType,
+              _llmDesc,
+              _llmViz,
+              _llmScores,
+            );
+          }, 100);
+        }
+      }
+
       // Raw JSON toggle
       const rawJson = {};
       for (const [k, v] of Object.entries(results)) {
-        if (!k.toLowerCase().includes('visualization')) rawJson[k] = v;
+        if (!k.toLowerCase().includes("visualization")) rawJson[k] = v;
       }
       html += `<details class="mt-4 border-t border-gray-200 dark:border-gray-700 pt-3">`;
       html += `<summary class="cursor-pointer inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">`;
@@ -455,15 +704,18 @@ function renderWorkspaceResults(data) {
   }
 
   // Don't show "no results" if there are async tasks being polled
-  const hasAsync = Object.values(data).some(r => typeof r === 'object' && r !== null && r.is_async);
+  const hasAsync = Object.values(data).some(
+    (r) => typeof r === "object" && r !== null && r.is_async,
+  );
   if (!html && !hasAsync) {
-    html = '<p class="text-center text-sm py-4" style="color: var(--textColorSecondary);">No results returned.</p>';
+    html =
+      '<p class="text-center text-sm py-4" style="color: var(--textColorSecondary);">No results returned.</p>';
   }
 
   metrics.innerHTML = html;
 
-  const buttonsContainer = document.getElementById('buttonsContainer');
-  if (buttonsContainer) buttonsContainer.style.display = 'flex';
+  const buttonsContainer = document.getElementById("buttonsContainer");
+  if (buttonsContainer) buttonsContainer.style.display = "flex";
 }
 
 /**
@@ -475,7 +727,7 @@ function renderWorkspaceResults(data) {
  */
 function renderScoresSection(scores, depth) {
   depth = depth || 0;
-  let html = '';
+  let html = "";
 
   for (const [key, value] of Object.entries(scores)) {
     // Flat dict of {feature: number} → Flowbite striped table
@@ -493,7 +745,10 @@ function renderScoresSection(scores, depth) {
       html += `</tr></thead><tbody>`;
       let rowIdx = 0;
       for (const [k, v] of Object.entries(value)) {
-        const stripe = rowIdx % 2 === 0 ? 'bg-white dark:bg-gray-800' : 'bg-gray-50 dark:bg-gray-700/50';
+        const stripe =
+          rowIdx % 2 === 0
+            ? "bg-white dark:bg-gray-800"
+            : "bg-gray-50 dark:bg-gray-700/50";
         html += `<tr class="${stripe} border-b dark:border-gray-700">`;
         html += `<td class="px-4 py-2 font-medium text-gray-900 dark:text-white whitespace-nowrap">${k}</td>`;
         html += `<td class="px-4 py-2 text-right font-mono text-xs">${formatValue(v)}</td>`;
@@ -504,9 +759,9 @@ function renderScoresSection(scores, depth) {
     }
     // Nested dict → collapsible Flowbite accordion-style section
     else if (isObject(value) && Object.keys(value).length > 0) {
-      const isDeep = Object.values(value).some(v => isObject(v));
+      const isDeep = Object.values(value).some((v) => isObject(v));
       if (isDeep || Object.keys(value).length > 5) {
-        html += `<details class="mb-3 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden" ${depth === 0 ? 'open' : ''}>`;
+        html += `<details class="mb-3 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden" ${depth === 0 ? "open" : ""}>`;
         html += `<summary class="cursor-pointer flex items-center justify-between px-4 py-2.5 text-sm font-medium text-gray-900 dark:text-white bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">`;
         html += `${key}<svg class="w-3 h-3 shrink-0 ml-2" viewBox="0 0 10 6"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1l4 4 4-4"/></svg>`;
         html += `</summary>`;
@@ -524,8 +779,8 @@ function renderScoresSection(scores, depth) {
     else if (Array.isArray(value)) {
       html += `<div class="mb-4">`;
       html += `<h4 class="text-xs font-semibold mb-2 uppercase tracking-wider text-gray-500 dark:text-gray-400">${key} <span class="normal-case font-normal">(${value.length})</span></h4>`;
-      if (value.length > 0 && typeof value[0] !== 'object') {
-        html += `<p class="text-sm text-gray-700 dark:text-gray-300">${value.map(formatValue).join(', ')}</p>`;
+      if (value.length > 0 && typeof value[0] !== "object") {
+        html += `<p class="text-sm text-gray-700 dark:text-gray-300">${value.map(formatValue).join(", ")}</p>`;
       } else {
         value.forEach((item, i) => {
           if (isObject(item)) {
@@ -541,7 +796,11 @@ function renderScoresSection(scores, depth) {
       html += `</div>`;
     }
     // Special: remedy download link
-    else if (key === 'apply_remedy' && typeof value === 'string' && value.includes('/download-remedy/')) {
+    else if (
+      key === "apply_remedy" &&
+      typeof value === "string" &&
+      value.includes("/download-remedy/")
+    ) {
       html += `<div class="flex justify-between items-center px-4 py-2.5 text-sm border-b border-gray-200 dark:border-gray-700">`;
       html += `<span class="font-medium text-gray-900 dark:text-white">Remedied Dataset</span>`;
       html += `<a href="${value}" class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white rounded-lg bg-green-600 hover:bg-green-700 focus:ring-4 focus:ring-green-300 dark:bg-green-500 dark:hover:bg-green-600 transition-colors">`;
@@ -565,27 +824,32 @@ function renderScoresSection(scores, depth) {
 
 /** Switch between Upload and Globus tabs on the landing page. */
 function switchUploadTab(tab) {
-  const localPanel = document.getElementById('local-upload');
-  const globusPanel = document.getElementById('globus-panel');
-  const tabLocal = document.getElementById('tab-local');
-  const tabGlobus = document.getElementById('tab-globus');
+  const localPanel = document.getElementById("local-upload");
+  const globusPanel = document.getElementById("globus-panel");
+  const tabLocal = document.getElementById("tab-local");
+  const tabGlobus = document.getElementById("tab-globus");
 
   if (!localPanel || !globusPanel) {
-    console.error('switchUploadTab: missing elements', { localPanel: !!localPanel, globusPanel: !!globusPanel });
+    console.error("switchUploadTab: missing elements", {
+      localPanel: !!localPanel,
+      globusPanel: !!globusPanel,
+    });
     return;
   }
 
-  const activeClass = 'border-blue-600 text-blue-600 dark:text-blue-500 dark:border-blue-500';
-  const inactiveClass = 'border-transparent text-gray-500 hover:text-gray-600 hover:border-gray-300 dark:text-gray-400';
+  const activeClass =
+    "border-blue-600 text-blue-600 dark:text-blue-500 dark:border-blue-500";
+  const inactiveClass =
+    "border-transparent text-gray-500 hover:text-gray-600 hover:border-gray-300 dark:text-gray-400";
 
-  if (tab === 'globus') {
-    localPanel.classList.add('hidden');
-    globusPanel.classList.remove('hidden');
+  if (tab === "globus") {
+    localPanel.classList.add("hidden");
+    globusPanel.classList.remove("hidden");
     tabLocal.className = `upload-tab flex-1 py-2.5 text-sm font-medium text-center border-b-2 ${inactiveClass}`;
     tabGlobus.className = `upload-tab flex-1 py-2.5 text-sm font-medium text-center border-b-2 ${activeClass}`;
   } else {
-    localPanel.classList.remove('hidden');
-    globusPanel.classList.add('hidden');
+    localPanel.classList.remove("hidden");
+    globusPanel.classList.add("hidden");
     tabLocal.className = `upload-tab flex-1 py-2.5 text-sm font-medium text-center border-b-2 ${activeClass}`;
     tabGlobus.className = `upload-tab flex-1 py-2.5 text-sm font-medium text-center border-b-2 ${inactiveClass}`;
   }
@@ -600,27 +864,28 @@ function fetchGlobusSummary() {
 
   if (!endpointId || !filePath) return;
 
-  fetch('/globus/submit', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  fetch("/globus/submit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       endpoint_id: endpointId,
       file_path: filePath,
       file_name: fileName,
       file_type: fileType,
-      metric_name: 'summary_statistics',
+      metric_name: "summary_statistics",
       params: {},
     }),
   })
-    .then(r => r.json())
-    .then(data => {
+    .then((r) => r.json())
+    .then((data) => {
       if (data.error) {
-        const loading = document.getElementById('globus-summary-loading');
-        if (loading) loading.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400">${data.error}</div>`;
+        const loading = document.getElementById("globus-summary-loading");
+        if (loading)
+          loading.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400">${data.error}</div>`;
         return;
       }
       // Cached result — render immediately without polling
-      if (data.status === 'completed' && data.result) {
+      if (data.status === "completed" && data.result) {
         renderGlobusSummary(data.result);
         return;
       }
@@ -628,20 +893,22 @@ function fetchGlobusSummary() {
         pollGlobusSummary(data.task_id);
       }
     })
-    .catch(err => {
-      const loading = document.getElementById('globus-summary-loading');
-      if (loading) loading.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400">Failed to connect: ${err.message}</div>`;
+    .catch((err) => {
+      const loading = document.getElementById("globus-summary-loading");
+      if (loading)
+        loading.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400">Failed to connect: ${err.message}</div>`;
     });
 }
 
 /** Render Globus summary data (used by both cached and polled paths). */
 function renderGlobusSummary(data) {
-  const loading = document.getElementById('globus-summary-loading');
-  const content = document.getElementById('globus-summary-content');
-  if (loading) loading.style.display = 'none';
+  const loading = document.getElementById("globus-summary-loading");
+  const content = document.getElementById("globus-summary-content");
+  if (loading) loading.style.display = "none";
 
   if (data.error) {
-    if (content) content.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400">${data.error}</div>`;
+    if (content)
+      content.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400">${data.error}</div>`;
     _unlockGlobusSidebar();
     return;
   }
@@ -670,40 +937,63 @@ function renderGlobusSummary(data) {
 
     if (data.summary_statistics) {
       const features = Object.keys(data.summary_statistics);
-      const allStats = features.length > 0 ? Object.keys(data.summary_statistics[features[0]]) : [];
-      const preferredOrder = ['count', 'min', '25th percentile', '50th percentile', 'mean', '75th percentile', 'max', 'std'];
-      const statKeys = preferredOrder.filter(s => allStats.includes(s)).concat(allStats.filter(s => !preferredOrder.includes(s)));
+      const allStats =
+        features.length > 0
+          ? Object.keys(data.summary_statistics[features[0]])
+          : [];
+      const preferredOrder = [
+        "count",
+        "min",
+        "25th percentile",
+        "50th percentile",
+        "mean",
+        "75th percentile",
+        "max",
+        "std",
+      ];
+      const statKeys = preferredOrder
+        .filter((s) => allStats.includes(s))
+        .concat(allStats.filter((s) => !preferredOrder.includes(s)));
 
       html += '<div class="relative overflow-x-auto rounded-lg shadow-sm">';
-      html += '<table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">';
-      html += '<thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400"><tr>';
+      html +=
+        '<table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">';
+      html +=
+        '<thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400"><tr>';
       html += '<th scope="col" class="px-4 py-3">Feature</th>';
-      statKeys.forEach(s => { html += `<th scope="col" class="px-4 py-3 text-right">${s}</th>`; });
-      html += '</tr></thead><tbody>';
+      statKeys.forEach((s) => {
+        html += `<th scope="col" class="px-4 py-3 text-right">${s}</th>`;
+      });
+      html += "</tr></thead><tbody>";
       features.forEach((feat, i) => {
-        const stripe = i % 2 === 0 ? 'bg-white dark:bg-gray-800' : 'bg-gray-50 dark:bg-gray-700/50';
+        const stripe =
+          i % 2 === 0
+            ? "bg-white dark:bg-gray-800"
+            : "bg-gray-50 dark:bg-gray-700/50";
         html += `<tr class="${stripe} border-b dark:border-gray-700">`;
         html += `<td class="px-4 py-2 font-medium text-gray-900 dark:text-white whitespace-nowrap">${feat}</td>`;
-        statKeys.forEach(s => { html += `<td class="px-4 py-2 font-mono text-xs text-right">${data.summary_statistics[feat][s] ?? '—'}</td>`; });
-        html += '</tr>';
+        statKeys.forEach((s) => {
+          html += `<td class="px-4 py-2 font-mono text-xs text-right">${data.summary_statistics[feat][s] ?? "—"}</td>`;
+        });
+        html += "</tr>";
       });
-      html += '</tbody></table></div>';
+      html += "</tbody></table></div>";
     }
 
     content.innerHTML = html;
   }
 
   // Render histograms if available
-  if (data.histograms && typeof renderWorkspaceHistograms === 'function') {
-    var wh = document.getElementById('workspace-histograms');
+  if (data.histograms && typeof renderWorkspaceHistograms === "function") {
+    var wh = document.getElementById("workspace-histograms");
     if (wh) {
-      wh.style.display = 'block';
+      wh.style.display = "block";
       renderWorkspaceHistograms(data.histograms);
     }
   }
 
   // Populate feature dropdowns for metric panels
-  if (data.all_features && typeof populateWorkspaceDropdowns === 'function') {
+  if (data.all_features && typeof populateWorkspaceDropdowns === "function") {
     populateWorkspaceDropdowns(data);
   }
 
@@ -711,9 +1001,10 @@ function renderGlobusSummary(data) {
 }
 
 function _unlockGlobusSidebar() {
-  var sidebarMetrics = document.getElementById('sidebar-metrics');
-  if (sidebarMetrics) sidebarMetrics.classList.remove('opacity-50', 'pointer-events-none');
-  var loadingMsg = document.getElementById('sidebar-loading-msg');
+  var sidebarMetrics = document.getElementById("sidebar-metrics");
+  if (sidebarMetrics)
+    sidebarMetrics.classList.remove("opacity-50", "pointer-events-none");
+  var loadingMsg = document.getElementById("sidebar-loading-msg");
   if (loadingMsg) loadingMsg.remove();
 }
 
@@ -725,26 +1016,26 @@ function pollGlobusSummary(taskId) {
   const poll = () => {
     attempts++;
     fetch(`/globus/check-task/${taskId}`)
-      .then(r => r.json())
-      .then(response => {
-        if (response.status === 'completed' && response.result) {
+      .then((r) => r.json())
+      .then((response) => {
+        if (response.status === "completed" && response.result) {
           renderGlobusSummary(response.result);
           // Cache the result so page reloads don't re-fetch
-          fetch('/globus/cache-summary', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+          fetch("/globus/cache-summary", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
             body: JSON.stringify(response.result),
           }).catch(() => {}); // Best-effort cache
-
-        } else if (response.status === 'failed') {
-          const loading = document.getElementById('globus-summary-loading');
-          if (loading) loading.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400">${response.error || 'Failed to load summary'}</div>`;
+        } else if (response.status === "failed") {
+          const loading = document.getElementById("globus-summary-loading");
+          if (loading)
+            loading.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400">${response.error || "Failed to load summary"}</div>`;
           _unlockGlobusSidebar();
         } else if (attempts < maxAttempts) {
           setTimeout(poll, 2000);
         }
       })
-      .catch(err => {
+      .catch((err) => {
         if (attempts < maxAttempts) setTimeout(poll, 3000);
       });
   };
@@ -754,88 +1045,109 @@ function pollGlobusSummary(taskId) {
 
 /** Disconnect from Globus — clear tokens. */
 function disconnectGlobus() {
-  fetch('/globus/disconnect', { method: 'POST' })
+  fetch("/globus/disconnect", { method: "POST" })
     .then(() => window.location.reload())
-    .catch(err => console.error('Globus disconnect error:', err));
+    .catch((err) => console.error("Globus disconnect error:", err));
 }
 
 /** Load a remote dataset via Globus Compute. */
 function loadGlobusDataset() {
-  const endpointId = document.getElementById('globus-endpoint-id')?.value?.trim();
-  const filePath = document.getElementById('globus-file-path')?.value?.trim();
-  const fileType = document.getElementById('globus-file-type')?.value;
+  const endpointId = document
+    .getElementById("globus-endpoint-id")
+    ?.value?.trim();
+  const filePath = document.getElementById("globus-file-path")?.value?.trim();
+  const fileType = document.getElementById("globus-file-type")?.value;
 
   if (!endpointId || !filePath) {
-    if (typeof showToast === 'function') showToast('Please fill in endpoint UUID and file path', 'error');
+    if (typeof showToast === "function")
+      showToast("Please fill in endpoint UUID and file path", "error");
     return;
   }
 
   // Disable the form to prevent double-clicking
-  const loadBtn = document.querySelector('#globusForm button[onclick*="loadGlobusDataset"]');
-  const inputs = document.querySelectorAll('#globusForm input, #globusForm select');
+  const loadBtn = document.querySelector(
+    '#globusForm button[onclick*="loadGlobusDataset"]',
+  );
+  const inputs = document.querySelectorAll(
+    "#globusForm input, #globusForm select",
+  );
   if (loadBtn) {
     loadBtn.disabled = true;
-    loadBtn.classList.add('opacity-50', 'cursor-not-allowed');
-    loadBtn.textContent = 'Connecting...';
+    loadBtn.classList.add("opacity-50", "cursor-not-allowed");
+    loadBtn.textContent = "Connecting...";
   }
-  inputs.forEach(el => { el.disabled = true; el.classList.add('opacity-50'); });
+  inputs.forEach((el) => {
+    el.disabled = true;
+    el.classList.add("opacity-50");
+  });
 
-  const fileName = filePath.split('/').pop();
+  const fileName = filePath.split("/").pop();
 
-  if (typeof showToast === 'function') showToast('Connecting to remote endpoint...', 'info');
+  if (typeof showToast === "function")
+    showToast("Connecting to remote endpoint...", "info");
 
-  fetch('/globus/submit', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  fetch("/globus/submit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       endpoint_id: endpointId,
       file_path: filePath,
       file_name: fileName,
       file_type: fileType,
-      metric_name: 'completeness',
+      metric_name: "completeness",
       params: {},
     }),
   })
-    .then(r => r.json())
-    .then(data => {
+    .then((r) => r.json())
+    .then((data) => {
       if (data.error) {
         _reEnableGlobusForm();
-        if (typeof showToast === 'function') showToast(data.error, 'error');
+        if (typeof showToast === "function") showToast(data.error, "error");
         return;
       }
       // Reload the page — session now has globus file info,
       // inspector will show sidebar + panels
-      window.location.href = '/inspector';
+      window.location.href = "/inspector";
     })
-    .catch(err => {
+    .catch((err) => {
       _reEnableGlobusForm();
-      if (typeof showToast === 'function') showToast('Failed to connect: ' + err.message, 'error');
+      if (typeof showToast === "function")
+        showToast("Failed to connect: " + err.message, "error");
     });
 }
 
 function _reEnableGlobusForm() {
-  const loadBtn = document.querySelector('#globusForm button[onclick*="loadGlobusDataset"]');
-  const inputs = document.querySelectorAll('#globusForm input, #globusForm select');
+  const loadBtn = document.querySelector(
+    '#globusForm button[onclick*="loadGlobusDataset"]',
+  );
+  const inputs = document.querySelectorAll(
+    "#globusForm input, #globusForm select",
+  );
   if (loadBtn) {
     loadBtn.disabled = false;
-    loadBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-    loadBtn.textContent = 'Load Remote Dataset';
+    loadBtn.classList.remove("opacity-50", "cursor-not-allowed");
+    loadBtn.textContent = "Load Remote Dataset";
   }
-  inputs.forEach(el => { el.disabled = false; el.classList.remove('opacity-50'); });
+  inputs.forEach((el) => {
+    el.disabled = false;
+    el.classList.remove("opacity-50");
+  });
 }
 
 let _globusSubmitInProgress = false;
 
 /** Disable or enable all submit buttons in metric panels. */
 function _setSubmitButtonsDisabled(disabled) {
-  document.querySelectorAll('.metric-panel button[onclick*="workspaceSubmit"]').forEach(btn => {
-    btn.disabled = disabled;
-    if (disabled) {
-      btn.classList.add('opacity-50', 'cursor-not-allowed');
-    } else {
-      btn.classList.remove('opacity-50', 'cursor-not-allowed');
-    }
-  });
+  document
+    .querySelectorAll('.metric-panel button[onclick*="workspaceSubmit"]')
+    .forEach((btn) => {
+      btn.disabled = disabled;
+      if (disabled) {
+        btn.classList.add("opacity-50", "cursor-not-allowed");
+      } else {
+        btn.classList.remove("opacity-50", "cursor-not-allowed");
+      }
+    });
 }
 
 /** Called when a Globus task finishes (success or failure). */
@@ -847,17 +1159,22 @@ function _globusTaskDone() {
 /** Submit a metric to run on a remote Globus Compute endpoint. */
 function submitGlobusMetric(metricName, params, displayName) {
   if (_globusSubmitInProgress) {
-    if (typeof showToast === 'function') showToast('A task is already running on the remote endpoint. Please wait.', 'info');
+    if (typeof showToast === "function")
+      showToast(
+        "A task is already running on the remote endpoint. Please wait.",
+        "info",
+      );
     return;
   }
 
-  const endpointId = window.AIDRIN_GLOBUS_ENDPOINT || '';
-  const filePath = window.AIDRIN_GLOBUS_FILE_PATH || '';
-  const fileName = window.AIDRIN_GLOBUS_FILE_NAME || '';
-  const fileType = window.AIDRIN_GLOBUS_FILE_TYPE || '';
+  const endpointId = window.AIDRIN_GLOBUS_ENDPOINT || "";
+  const filePath = window.AIDRIN_GLOBUS_FILE_PATH || "";
+  const fileName = window.AIDRIN_GLOBUS_FILE_NAME || "";
+  const fileType = window.AIDRIN_GLOBUS_FILE_TYPE || "";
 
   if (!endpointId || !filePath) {
-    if (typeof showToast === 'function') showToast('No remote file configured', 'error');
+    if (typeof showToast === "function")
+      showToast("No remote file configured", "error");
     return;
   }
 
@@ -866,12 +1183,12 @@ function submitGlobusMetric(metricName, params, displayName) {
   _setSubmitButtonsDisabled(true);
 
   // Show results section with spinner
-  const resultsSection = document.getElementById('results-section');
-  if (resultsSection) resultsSection.style.display = 'block';
+  const resultsSection = document.getElementById("results-section");
+  if (resultsSection) resultsSection.style.display = "block";
 
-  fetch('/globus/submit', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  fetch("/globus/submit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       endpoint_id: endpointId,
       file_path: filePath,
@@ -881,27 +1198,33 @@ function submitGlobusMetric(metricName, params, displayName) {
       params: params || {},
     }),
   })
-    .then(r => r.json())
-    .then(data => {
+    .then((r) => r.json())
+    .then((data) => {
       if (data.error) {
         _globusTaskDone();
-        const m = document.getElementById('metrics');
-        if (m) m.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">${data.error}</div>`;
+        const m = document.getElementById("metrics");
+        if (m)
+          m.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">${data.error}</div>`;
         return;
       }
       if (data.task_id && data.is_async) {
         // Reuse existing async polling — but use Globus check endpoint
-        pollAsyncMetric(data.task_id, displayName || metricName, null, '/globus/check-task/');
+        pollAsyncMetric(
+          data.task_id,
+          displayName || metricName,
+          null,
+          "/globus/check-task/",
+        );
       } else {
         _globusTaskDone();
       }
     })
-    .catch(err => {
+    .catch((err) => {
       _globusTaskDone();
-      if (typeof showToast === 'function') showToast('Globus submit error: ' + err.message, 'error');
+      if (typeof showToast === "function")
+        showToast("Globus submit error: " + err.message, "error");
     });
 }
-
 
 // ==================== Layout Helpers ====================
 
@@ -915,10 +1238,9 @@ function syncScoresHeight(pairId) {
   if (img && scores) {
     const imgHeight = img.offsetHeight;
     const minHeight = 400;
-    scores.style.maxHeight = Math.max(imgHeight, minHeight) + 'px';
+    scores.style.maxHeight = Math.max(imgHeight, minHeight) + "px";
   }
 }
-
 
 // ==================== Async Task Polling ====================
 
@@ -927,7 +1249,12 @@ function syncScoresHeight(pairId) {
  */
 function handleAsyncResults(data) {
   for (const [type, results] of Object.entries(data)) {
-    if (typeof results === 'object' && results !== null && results.is_async && results.task_id) {
+    if (
+      typeof results === "object" &&
+      results !== null &&
+      results.is_async &&
+      results.task_id
+    ) {
       pollAsyncMetric(results.task_id, type, results.cache_key);
     }
   }
@@ -937,33 +1264,33 @@ function handleAsyncResults(data) {
  * Poll an async metric task until complete, showing progress inline.
  */
 function pollAsyncMetric(taskId, metricName, cacheKey, checkUrlBase) {
-  checkUrlBase = checkUrlBase || '/check-and-update-task/';
+  checkUrlBase = checkUrlBase || "/check-and-update-task/";
   // Find or create a placeholder in the results area
-  const resultsSection = document.getElementById('results-section');
-  if (resultsSection) resultsSection.style.display = 'block';
+  const resultsSection = document.getElementById("results-section");
+  if (resultsSection) resultsSection.style.display = "block";
 
-  const metricsDiv = document.getElementById('metrics');
+  const metricsDiv = document.getElementById("metrics");
   if (!metricsDiv) return;
 
   // Human-readable metric names for the spinner card
   const metricDisplayNames = {
-    'data_quality': 'Data Quality',
-    'completeness': 'Completeness',
-    'outliers': 'Outliers',
-    'duplicates': 'Duplicity',
-    'correlations': 'Correlation Analysis',
-    'feature_relevance': 'Feature Relevance',
-    'representation_rate': 'Representation Rate',
-    'statistical_rates': 'Statistical Rates',
-    'class_distribution': 'Class Imbalance',
-    'k_anonymity': 'k-Anonymity',
-    'l_diversity': 'l-Diversity',
-    't_closeness': 't-Closeness',
-    'entropy_risk': 'Entropy Risk',
-    'hipaa': 'HIPAA Compliance',
-    'privacy_preservation': 'Privacy Preservation',
-    'fairness': 'Fairness',
-    'Completeness': 'Completeness',
+    data_quality: "Data Quality",
+    completeness: "Completeness",
+    outliers: "Outliers",
+    duplicates: "Duplicity",
+    correlations: "Correlation Analysis",
+    feature_relevance: "Feature Relevance",
+    representation_rate: "Representation Rate",
+    statistical_rates: "Statistical Rates",
+    class_distribution: "Class Imbalance",
+    k_anonymity: "k-Anonymity",
+    l_diversity: "l-Diversity",
+    t_closeness: "t-Closeness",
+    entropy_risk: "Entropy Risk",
+    hipaa: "HIPAA Compliance",
+    privacy_preservation: "Privacy Preservation",
+    fairness: "Fairness",
+    Completeness: "Completeness",
   };
   const displayName = metricDisplayNames[metricName] || metricName;
 
@@ -971,15 +1298,16 @@ function pollAsyncMetric(taskId, metricName, cacheKey, checkUrlBase) {
   const placeholderId = `async-${taskId}`;
   let existing = document.getElementById(placeholderId);
   if (!existing) {
-    const card = document.createElement('div');
+    const card = document.createElement("div");
     card.id = placeholderId;
-    card.className = 'p-5 mb-4 bg-white border border-gray-200 rounded-lg shadow-sm dark:bg-gray-800 dark:border-gray-700';
+    card.className =
+      "p-5 mb-4 bg-white border border-gray-200 rounded-lg shadow-sm dark:bg-gray-800 dark:border-gray-700";
     card.innerHTML = `
       <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-3">${displayName}</h3>
       <div class="flex items-center gap-3">
         <svg class="w-5 h-5 text-gray-300 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101"><path d="M100 50.59c0 27.61-22.39 50-50 50S0 78.2 0 50.59 22.39.59 50 .59s50 22.39 50 50zm-90.92 0c0 22.6 18.32 40.92 40.92 40.92s40.92-18.32 40.92-40.92S72.6 9.67 50 9.67 9.08 28 9.08 50.59z" fill="currentColor"/><path d="M93.97 39.04c2.43-.64 3.93-3.13 3.04-5.5A50 50 0 0048.44.58c-2.5.23-4.21 2.53-3.73 5l.02.1a3.89 3.89 0 004.57 3.13A41.1 41.1 0 0188.18 37.2a3.88 3.88 0 005.79 1.84z" fill="currentFill"/></svg>
         <div>
-          <p class="text-sm text-gray-700 dark:text-gray-300">${checkUrlBase.includes('globus') ? 'Running on Globus Compute Endpoint...' : 'Processing...'}</p>
+          <p class="text-sm text-gray-700 dark:text-gray-300">${checkUrlBase.includes("globus") ? "Running on Globus Compute Endpoint..." : "Processing..."}</p>
           <div class="w-48 bg-gray-200 rounded-full h-1.5 dark:bg-gray-700 mt-1">
             <div id="${placeholderId}-bar" class="bg-blue-600 h-1.5 rounded-full transition-all" style="width: 0%"></div>
           </div>
@@ -995,16 +1323,16 @@ function pollAsyncMetric(taskId, metricName, cacheKey, checkUrlBase) {
 
   const poll = () => {
     attempts++;
-    const checkUrl = checkUrlBase.includes('globus')
+    const checkUrl = checkUrlBase.includes("globus")
       ? `${checkUrlBase}${taskId}`
       : `${checkUrlBase}${taskId}/${encodeURIComponent(metricName)}`;
     fetch(checkUrl)
-      .then(r => r.json())
-      .then(response => {
+      .then((r) => r.json())
+      .then((response) => {
         const card = document.getElementById(placeholderId);
         if (!card) return;
 
-        if (response.status === 'completed') {
+        if (response.status === "completed") {
           // Update stored result for download
           if (lastMetricResult) {
             lastMetricResult[metricName] = response.result;
@@ -1014,16 +1342,24 @@ function pollAsyncMetric(taskId, metricName, cacheKey, checkUrlBase) {
           // {Completeness: {...}, Outliers: {...}, Duplicity: {...}})
           // vs a single metric result (has Description/Visualization at top level)
           const result = response.result;
-          const isBundle = typeof result === 'object' && result !== null
-            && !result.Description && !result.Error
-            && Object.values(result).some(v => typeof v === 'object' && v !== null && (v.Description || v.Error));
+          const isBundle =
+            typeof result === "object" &&
+            result !== null &&
+            !result.Description &&
+            !result.Error &&
+            Object.values(result).some(
+              (v) =>
+                typeof v === "object" &&
+                v !== null &&
+                (v.Description || v.Error),
+            );
 
-          const tempDiv = document.createElement('div');
+          const tempDiv = document.createElement("div");
           if (isBundle) {
             // Render each sub-metric as its own card (matches local renderWorkspaceResults)
-            let html = '';
+            let html = "";
             for (const [subType, subResult] of Object.entries(result)) {
-              if (typeof subResult === 'object' && subResult !== null) {
+              if (typeof subResult === "object" && subResult !== null) {
                 html += buildResultCard(subType, subResult);
               }
             }
@@ -1037,32 +1373,34 @@ function pollAsyncMetric(taskId, metricName, cacheKey, checkUrlBase) {
           while (tempDiv.firstChild) fragment.appendChild(tempDiv.firstChild);
           card.replaceWith(fragment);
           _globusTaskDone();
-
-        } else if (response.status === 'failed') {
+        } else if (response.status === "failed") {
           _globusTaskDone();
           card.innerHTML = `
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-3">${metricName}</h3>
             <div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">
-              ${response.error || 'Task failed'}
+              ${response.error || "Task failed"}
             </div>`;
-
-        } else if (response.status === 'processing') {
+        } else if (response.status === "processing") {
           // Update progress bar
           const progress = response.progress || {};
-          const pct = progress.total > 0 ? Math.round((progress.current / progress.total) * 100) : 0;
+          const pct =
+            progress.total > 0
+              ? Math.round((progress.current / progress.total) * 100)
+              : 0;
           const bar = document.getElementById(`${placeholderId}-bar`);
           if (bar) bar.style.width = `${pct}%`;
 
-          const statusText = card.querySelector('p');
-          if (statusText) statusText.textContent = progress.status || 'Processing...';
+          const statusText = card.querySelector("p");
+          if (statusText)
+            statusText.textContent = progress.status || "Processing...";
 
           if (attempts < maxAttempts) {
             setTimeout(poll, 2000);
           }
         }
       })
-      .catch(err => {
-        console.error('Polling error:', err);
+      .catch((err) => {
+        console.error("Polling error:", err);
         if (attempts < maxAttempts) {
           setTimeout(poll, 3000);
         } else {
@@ -1079,18 +1417,32 @@ function pollAsyncMetric(taskId, metricName, cacheKey, checkUrlBase) {
  * Reuses the same rendering logic as renderWorkspaceResults but for one entry.
  */
 function buildResultCard(type, results) {
-  if (typeof results !== 'object' || results === null) return '';
+  if (typeof results !== "object" || results === null) return "";
 
-  const description = results.Description || '';
-  const error = results.Error || '';
-  const interpretation = results['Graph interpretation'];
+  const description = results.Description || "";
+  const error = results.Error || "";
+  const interpretation = results["Graph interpretation"];
   const visualizations = [];
   const scores = {};
 
   for (const [key, value] of Object.entries(results)) {
-    if (key === 'Description' || key === 'Error' || key === 'Graph interpretation') continue;
-    if (key.toLowerCase().includes('visualization') && typeof value === 'string' && value.length > 100) {
-      visualizations.push({ key, src: value.startsWith('data:') ? value : `data:image/png;base64,${value}` });
+    if (
+      key === "Description" ||
+      key === "Error" ||
+      key === "Graph interpretation"
+    )
+      continue;
+    if (
+      key.toLowerCase().includes("visualization") &&
+      typeof value === "string" &&
+      value.length > 100
+    ) {
+      visualizations.push({
+        key,
+        src: value.startsWith("data:")
+          ? value
+          : `data:image/png;base64,${value}`,
+      });
     } else {
       scores[key] = value;
     }
@@ -1109,15 +1461,18 @@ function buildResultCard(type, results) {
     const hasViz = visualizations.length > 0;
     const hasScores = Object.keys(scores).length > 0;
 
-    const asyncPairId = 'result-pair-' + Math.random().toString(36).substr(2, 6);
+    const asyncPairId =
+      "result-pair-" + Math.random().toString(36).substr(2, 6);
     if (hasViz || hasScores) {
-      html += `<div class="grid gap-4" style="grid-template-columns: ${hasViz && hasScores ? '1fr 1fr' : '1fr'};">`;
+      html += `<div class="grid gap-4" style="grid-template-columns: ${hasViz && hasScores ? "1fr 1fr" : "1fr"};">`;
       if (hasViz) {
         html += `<div class="flex flex-col items-center gap-4">`;
         for (const viz of visualizations) {
           const isHeatmap = /correlation|heatmap/i.test(viz.key);
-          const imgStyle = isHeatmap ? ' style="max-width:500px; max-height:500px; object-fit:contain;"' : '';
-          html += `<img src="${viz.src}" alt="${viz.key}" class="rounded-lg ${isHeatmap ? '' : 'w-full'}"${imgStyle} data-pair="${asyncPairId}" onload="syncScoresHeight('${asyncPairId}')" />`;
+          const imgStyle = isHeatmap
+            ? ' style="max-width:500px; max-height:500px; object-fit:contain;"'
+            : "";
+          html += `<img src="${viz.src}" alt="${viz.key}" class="rounded-lg ${isHeatmap ? "" : "w-full"}"${imgStyle} data-pair="${asyncPairId}" onload="syncScoresHeight('${asyncPairId}')" />`;
         }
         html += `</div>`;
       }
@@ -1127,7 +1482,11 @@ function buildResultCard(type, results) {
       html += `</div>`;
     }
 
-    if (interpretation && typeof interpretation === 'string' && !interpretation.includes('No visualization available')) {
+    if (
+      interpretation &&
+      typeof interpretation === "string" &&
+      !interpretation.includes("No visualization available")
+    ) {
       html += `<div class="flex items-start gap-2.5 p-4 mt-4 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50">
         <svg class="w-5 h-5 shrink-0 mt-0.5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 011.037-.443 48.282 48.282 0 005.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"/></svg>
         <div>
@@ -1136,12 +1495,20 @@ function buildResultCard(type, results) {
         </div>
       </div>`;
     }
+
+    // AI Explanation placeholder (filled async if LLM is configured)
+    if (window.AIDRIN_LLM_ENABLED && (hasViz || hasScores)) {
+      const llmId = "llm-async-" + Math.random().toString(36).substr(2, 6);
+      html += `<div id="${llmId}" class="mt-3"></div>`;
+      setTimeout(() => {
+        requestLLMExplanation(llmId, type, description, visualizations, scores);
+      }, 100);
+    }
   }
 
   html += `</div>`;
   return html;
 }
-
 
 // ==================== Toast Notifications ====================
 
@@ -1152,20 +1519,32 @@ function buildResultCard(type, results) {
  * @param {number} duration - Auto-dismiss in ms (default 4000)
  */
 function showToast(message, type, duration) {
-  type = type || 'info';
+  type = type || "info";
   duration = duration || 4000;
 
   const colors = {
-    success: { bg: 'bg-green-100 dark:bg-green-800', text: 'text-green-500 dark:text-green-200', icon: '<path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>' },
-    error:   { bg: 'bg-red-100 dark:bg-red-800', text: 'text-red-500 dark:text-red-200', icon: '<path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>' },
-    info:    { bg: 'bg-blue-100 dark:bg-blue-800', text: 'text-blue-500 dark:text-blue-200', icon: '<path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>' },
+    success: {
+      bg: "bg-green-100 dark:bg-green-800",
+      text: "text-green-500 dark:text-green-200",
+      icon: '<path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>',
+    },
+    error: {
+      bg: "bg-red-100 dark:bg-red-800",
+      text: "text-red-500 dark:text-red-200",
+      icon: '<path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>',
+    },
+    info: {
+      bg: "bg-blue-100 dark:bg-blue-800",
+      text: "text-blue-500 dark:text-blue-200",
+      icon: '<path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>',
+    },
   };
   const c = colors[type] || colors.info;
 
-  const toast = document.createElement('div');
+  const toast = document.createElement("div");
   toast.className = `fixed top-4 right-4 z-[9999] flex items-center w-full max-w-xs p-4 text-gray-500 bg-white rounded-lg shadow-lg dark:text-gray-400 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 transition-all`;
-  toast.style.opacity = '0';
-  toast.style.transform = 'translateY(-8px)';
+  toast.style.opacity = "0";
+  toast.style.transform = "translateY(-8px)";
   toast.innerHTML = `
     <div class="inline-flex items-center justify-center shrink-0 w-8 h-8 ${c.text} ${c.bg} rounded-lg">
       <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">${c.icon}</svg>
@@ -1180,19 +1559,18 @@ function showToast(message, type, duration) {
 
   // Animate in
   requestAnimationFrame(() => {
-    toast.style.transition = 'opacity 0.3s, transform 0.3s';
-    toast.style.opacity = '1';
-    toast.style.transform = 'translateY(0)';
+    toast.style.transition = "opacity 0.3s, transform 0.3s";
+    toast.style.opacity = "1";
+    toast.style.transform = "translateY(0)";
   });
 
   // Auto-dismiss
   setTimeout(() => {
-    toast.style.opacity = '0';
-    toast.style.transform = 'translateY(-8px)';
+    toast.style.opacity = "0";
+    toast.style.transform = "translateY(-8px)";
     setTimeout(() => toast.remove(), 300);
   }, duration);
 }
-
 
 // ==================== JSON Download ====================
 
@@ -1202,10 +1580,15 @@ function downloadJSON() {
   // Strip base64 visualization blobs to keep download small
   const clean = {};
   for (const [k, v] of Object.entries(lastMetricResult)) {
-    if (typeof v === 'object' && v !== null) {
+    if (typeof v === "object" && v !== null) {
       const inner = {};
       for (const [ik, iv] of Object.entries(v)) {
-        if (typeof iv === 'string' && iv.length > 1000 && ik.toLowerCase().includes('visualization')) continue;
+        if (
+          typeof iv === "string" &&
+          iv.length > 1000 &&
+          ik.toLowerCase().includes("visualization")
+        )
+          continue;
         inner[ik] = iv;
       }
       clean[k] = inner;
@@ -1213,16 +1596,17 @@ function downloadJSON() {
       clean[k] = v;
     }
   }
-  const blob = new Blob([JSON.stringify(clean, null, 2)], { type: 'application/json' });
-  const link = document.createElement('a');
+  const blob = new Blob([JSON.stringify(clean, null, 2)], {
+    type: "application/json",
+  });
+  const link = document.createElement("a");
   link.href = URL.createObjectURL(blob);
-  link.download = 'result.json';
+  link.download = "result.json";
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
   URL.revokeObjectURL(link.href);
 }
-
 
 // ==================== Checkbox Helpers ====================
 
@@ -1230,7 +1614,7 @@ function downloadJSON() {
 function toggleAllCheckboxes(btn, containerId, checked) {
   const el = document.getElementById(containerId);
   if (!el) return;
-  el.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+  el.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
     if (!cb.disabled) cb.checked = checked;
   });
   updateCheckboxCount(containerId);
@@ -1242,7 +1626,7 @@ function updateCheckboxCount(containerId) {
   if (!el) return;
   const all = el.querySelectorAll('input[type="checkbox"]');
   const checked = el.querySelectorAll('input[type="checkbox"]:checked');
-  const counter = document.getElementById(containerId + '-count');
+  const counter = document.getElementById(containerId + "-count");
   if (counter) {
     if (checked.length === 0) {
       counter.textContent = `${all.length} features`;
@@ -1252,31 +1636,37 @@ function updateCheckboxCount(containerId) {
   }
 }
 
-function isObject(v) { return typeof v === 'object' && v !== null && !Array.isArray(v); }
-function isFlatDict(obj) { return Object.values(obj).every(v => typeof v !== 'object' || v === null); }
+function isObject(v) {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+function isFlatDict(obj) {
+  return Object.values(obj).every((v) => typeof v !== "object" || v === null);
+}
 function formatValue(v) {
-  if (v === null || v === undefined) return '—';
-  if (typeof v === 'boolean') return v ? 'Yes' : 'No';
-  if (typeof v === 'number') return Number.isInteger(v) ? v.toString() : v.toFixed(4);
+  if (v === null || v === undefined) return "—";
+  if (typeof v === "boolean") return v ? "Yes" : "No";
+  if (typeof v === "number")
+    return Number.isInteger(v) ? v.toString() : v.toFixed(4);
   return String(v);
 }
 function escapeHtml(str) {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 // ==================== FAIR Assessment ====================
 
 function submitFairAssessment() {
-  const form = document.getElementById('form-fair-assessment');
+  const form = document.getElementById("form-fair-assessment");
   if (!form) return;
 
   const formData = new FormData(form);
-  const resultContainer = document.getElementById('fair-result-container');
-  if (resultContainer) resultContainer.innerHTML = '<p class="text-center">Processing...</p>';
+  const resultContainer = document.getElementById("fair-result-container");
+  if (resultContainer)
+    resultContainer.innerHTML = '<p class="text-center">Processing...</p>';
 
-  fetch('/fair-assessment', { method: 'POST', body: formData })
-    .then(response => response.json())
-    .then(data => {
+  fetch("/fair-assessment", { method: "POST", body: formData })
+    .then((response) => response.json())
+    .then((data) => {
       if (!resultContainer) return;
 
       // Check for error response
@@ -1285,11 +1675,11 @@ function submitFairAssessment() {
         return;
       }
 
-      let html = '';
+      let html = "";
 
       // Compliance summary bar — extract from FAIR Compliance Checks
-      const checks = data['FAIR Compliance Checks'] || {};
-      const totalCheck = checks['Total Checks'] || '';
+      const checks = data["FAIR Compliance Checks"] || {};
+      const totalCheck = checks["Total Checks"] || "";
       const totalMatch = totalCheck.match(/(\d+)\/(\d+)/);
       const totalPassed = totalMatch ? parseInt(totalMatch[1]) : 0;
       const totalExpected = totalMatch ? parseInt(totalMatch[2]) : 1;
@@ -1306,9 +1696,9 @@ function submitFairAssessment() {
         <div class="grid grid-cols-4 gap-3">`;
 
       // Per-principle mini bars
-      const fairKeys = ['Findable', 'Accessible', 'Interoperable', 'Reusable'];
-      fairKeys.forEach(k => {
-        const checkStr = checks[`${k} Checks`] || '0/0';
+      const fairKeys = ["Findable", "Accessible", "Interoperable", "Reusable"];
+      fairKeys.forEach((k) => {
+        const checkStr = checks[`${k} Checks`] || "0/0";
         const m = checkStr.match(/(\d+)\/(\d+)/);
         const passed = m ? parseInt(m[1]) : 0;
         const total = m ? parseInt(m[2]) : 1;
@@ -1321,14 +1711,14 @@ function submitFairAssessment() {
           </div>
         </div>`;
       });
-      html += '</div></div>';
+      html += "</div></div>";
 
       // FAIR principle details as collapsible accordions
       html += '<div class="space-y-2 mb-4">';
-      fairKeys.forEach(k => {
-        let val = '—';
-        let checkStr = checks[`${k} Checks`] || '';
-        if (data[k] !== undefined && typeof data[k] === 'object') {
+      fairKeys.forEach((k) => {
+        let val = "—";
+        let checkStr = checks[`${k} Checks`] || "";
+        if (data[k] !== undefined && typeof data[k] === "object") {
           val = renderFairValue(data[k]);
         } else if (data[k] !== undefined) {
           val = `<div class="py-2 text-sm text-gray-700 dark:text-gray-300">${data[k]}</div>`;
@@ -1341,16 +1731,20 @@ function submitFairAssessment() {
           <div class="px-4 py-3 border-t border-gray-200 dark:border-gray-700">${val}</div>
         </details>`;
       });
-      html += '</div>';
+      html += "</div>";
 
       // Other data (FAIR Compliance Checks, Other, Original Metadata)
-      const extraKeys = Object.keys(data).filter(k => !fairKeys.includes(k) && k !== 'Pie chart');
+      const extraKeys = Object.keys(data).filter(
+        (k) => !fairKeys.includes(k) && k !== "Pie chart",
+      );
       if (extraKeys.length > 0) {
-        html += '<div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-4">';
-        html += '<h3 class="text-base font-semibold text-gray-900 dark:text-white mb-3">Detailed Results</h3>';
-        extraKeys.forEach(k => {
+        html +=
+          '<div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-4">';
+        html +=
+          '<h3 class="text-base font-semibold text-gray-900 dark:text-white mb-3">Detailed Results</h3>';
+        extraKeys.forEach((k) => {
           const val = data[k];
-          if (typeof val === 'object' && val !== null) {
+          if (typeof val === "object" && val !== null) {
             html += `<details class="mb-2 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
               <summary class="cursor-pointer flex items-center justify-between px-4 py-2.5 text-sm font-medium text-gray-900 dark:text-white bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">
                 ${k}
@@ -1363,37 +1757,44 @@ function submitFairAssessment() {
           } else {
             html += `<div class="flex justify-between items-center px-4 py-2.5 text-sm border-b border-gray-200 dark:border-gray-700">
               <span class="font-medium text-gray-900 dark:text-white">${k}</span>
-              <span class="text-gray-500 dark:text-gray-400">${val ?? '—'}</span>
+              <span class="text-gray-500 dark:text-gray-400">${val ?? "—"}</span>
             </div>`;
           }
         });
-        html += '</div>';
+        html += "</div>";
       }
 
       resultContainer.innerHTML = html;
     })
-    .catch(error => {
-      console.error('Error:', error);
-      if (resultContainer) resultContainer.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">Error: ${error.message}</div>`;
+    .catch((error) => {
+      console.error("Error:", error);
+      if (resultContainer)
+        resultContainer.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">Error: ${error.message}</div>`;
     });
 }
 
 /** Render a FAIR value object as readable HTML with pass/fail badges */
 function renderFairValue(obj) {
-  if (typeof obj !== 'object' || obj === null) return String(obj ?? '—');
-  let html = '';
+  if (typeof obj !== "object" || obj === null) return String(obj ?? "—");
+  let html = "";
   for (const [k, v] of Object.entries(obj)) {
-    if (typeof v === 'object' && v !== null) {
+    if (typeof v === "object" && v !== null) {
       html += `<div class="mt-1.5"><span class="text-xs font-medium text-gray-700 dark:text-gray-300">${k}</span>${renderFairValue(v)}</div>`;
     } else {
       const strVal = String(v);
-      const isFail = strVal.includes('CHECK FAILED') || v === false || v === 'Fail' || v === 'No';
-      let badge = '';
+      const isFail =
+        strVal.includes("CHECK FAILED") ||
+        v === false ||
+        v === "Fail" ||
+        v === "No";
+      let badge = "";
       if (isFail) {
-        badge = '<span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">&#10007; Missing</span>';
+        badge =
+          '<span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">&#10007; Missing</span>';
       } else {
         // Truncate long values
-        const display = strVal.length > 60 ? strVal.substring(0, 57) + '...' : strVal;
+        const display =
+          strVal.length > 60 ? strVal.substring(0, 57) + "..." : strVal;
         badge = `<span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" title="${escapeHtml(strVal)}">&#10003; Found</span>`;
       }
       html += `<div class="flex items-center justify-between py-1.5 text-xs border-b border-gray-100 dark:border-gray-700 last:border-b-0">
@@ -1406,13 +1807,13 @@ function renderFairValue(obj) {
 // ==================== Custom Metrics ====================
 
 function initCodeMirror() {
-  const textarea = document.getElementById('metricCodeEditor');
+  const textarea = document.getElementById("metricCodeEditor");
   if (!textarea || codeMirrorEditor) return;
 
   codeMirrorEditor = CodeMirror.fromTextArea(textarea, {
-    mode: 'python',
+    mode: "python",
     lineNumbers: true,
-    theme: 'eclipse',
+    theme: "eclipse",
     indentUnit: 4,
     tabSize: 4,
     lineWrapping: true,
@@ -1422,42 +1823,44 @@ function initCodeMirror() {
   codeMirrorEditor.refresh();
 
   // Load existing code
-  fetch('/load-custom-metric')
-    .then(r => r.text())
-    .then(code => codeMirrorEditor.setValue(code))
-    .catch(err => console.error('Error loading custom metric:', err));
+  fetch("/load-custom-metric")
+    .then((r) => r.text())
+    .then((code) => codeMirrorEditor.setValue(code))
+    .catch((err) => console.error("Error loading custom metric:", err));
 }
 
 function saveCustomMetricFile() {
   if (!codeMirrorEditor) return;
   const code = codeMirrorEditor.getValue();
-  const applyRemedy = document.getElementById('apply_remedy')?.checked ? 'yes' : 'no';
+  const applyRemedy = document.getElementById("apply_remedy")?.checked
+    ? "yes"
+    : "no";
 
   const formData = new FormData();
-  formData.append('metric_code', code);
-  formData.append('apply_remedy', applyRemedy);
+  formData.append("metric_code", code);
+  formData.append("apply_remedy", applyRemedy);
 
-  fetch('/save-custom-metric-text', { method: 'POST', body: formData })
-    .then(r => r.json())
-    .then(data => {
+  fetch("/save-custom-metric-text", { method: "POST", body: formData })
+    .then((r) => r.json())
+    .then((data) => {
       if (data.message) {
         // Enable submit button after successful save
-        const submitBtn = document.getElementById('custom-metrics-submit');
+        const submitBtn = document.getElementById("custom-metrics-submit");
         if (submitBtn) {
           submitBtn.disabled = false;
         }
       }
-      showToast(data.message || data.error, data.error ? 'error' : 'success');
+      showToast(data.message || data.error, data.error ? "error" : "success");
     })
-    .catch(err => showToast('Error saving file: ' + err, 'error'));
+    .catch((err) => showToast("Error saving file: " + err, "error"));
 }
 
 function submitCustomMetric() {
   if (!codeMirrorEditor) return;
 
-  const resultsSection = document.getElementById('results-section');
-  if (resultsSection) resultsSection.style.display = 'block';
-  const metricsDiv = document.getElementById('metrics');
+  const resultsSection = document.getElementById("results-section");
+  if (resultsSection) resultsSection.style.display = "block";
+  const metricsDiv = document.getElementById("metrics");
   if (metricsDiv) {
     metricsDiv.innerHTML = `
       <div class="text-center py-8">
@@ -1469,24 +1872,28 @@ function submitCustomMetric() {
   }
 
   const formData = new FormData();
-  formData.append('metric_code', codeMirrorEditor.getValue());
-  formData.append('apply_remedy', document.getElementById('apply_remedy')?.checked ? 'yes' : 'no');
+  formData.append("metric_code", codeMirrorEditor.getValue());
+  formData.append(
+    "apply_remedy",
+    document.getElementById("apply_remedy")?.checked ? "yes" : "no",
+  );
 
-  fetch('/custom-metrics?return_type=json', {
-    method: 'POST',
+  fetch("/custom-metrics?return_type=json", {
+    method: "POST",
     body: formData,
   })
-    .then(response => {
+    .then((response) => {
       if (response.ok) return response.json();
       throw new Error(`Server error (${response.status})`);
     })
-    .then(data => {
+    .then((data) => {
       lastMetricResult = data;
       renderWorkspaceResults(data);
     })
-    .catch(error => {
-      console.error('Error:', error);
-      if (metricsDiv) metricsDiv.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">${error.message}</div>`;
+    .catch((error) => {
+      console.error("Error:", error);
+      if (metricsDiv)
+        metricsDiv.innerHTML = `<div class="p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-red-900/20 dark:text-red-400" role="alert">${error.message}</div>`;
     });
 }
 
@@ -1497,24 +1904,25 @@ function submitCustomMetric() {
  * @param {Object} histograms - Dict of {column_theme: base64_img} from /summary-statistics
  */
 function renderWorkspaceHistograms(histograms) {
-  const container = document.getElementById('workspace-histograms');
+  const container = document.getElementById("workspace-histograms");
   if (!container) return;
 
   // Always use the light variant — CSS filter handles dark mode
   const columns = {};
   for (const [key, base64] of Object.entries(histograms)) {
-    if (key.endsWith('_light')) {
-      const colName = key.slice(0, -'_light'.length);
+    if (key.endsWith("_light")) {
+      const colName = key.slice(0, -"_light".length);
       columns[colName] = base64;
     }
   }
 
   if (Object.keys(columns).length === 0) {
-    container.innerHTML = '';
+    container.innerHTML = "";
     return;
   }
 
-  let html = '<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-3 uppercase tracking-wide">Feature Distributions</h3>';
+  let html =
+    '<h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-3 uppercase tracking-wide">Feature Distributions</h3>';
   html += '<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">';
 
   for (const [colName, base64] of Object.entries(columns)) {
@@ -1526,10 +1934,9 @@ function renderWorkspaceHistograms(histograms) {
     `;
   }
 
-  html += '</div>';
+  html += "</div>";
   container.innerHTML = html;
 }
-
 
 // ==================== Workspace Init ====================
 
@@ -1539,17 +1946,18 @@ function renderWorkspaceHistograms(histograms) {
  */
 function initWorkspace() {
   // Restore panel from URL hash, or default to data-overview
-  const hash = location.hash.replace('#', '');
-  const initialPanel = hash && document.getElementById('panel-' + hash) ? hash : 'data-overview';
+  const hash = location.hash.replace("#", "");
+  const initialPanel =
+    hash && document.getElementById("panel-" + hash) ? hash : "data-overview";
   showPanel(initialPanel, false); // false = don't push to history on init
   // Replace current history entry so back button works from the first panel
-  history.replaceState({ panel: initialPanel }, '', '#' + initialPanel);
+  history.replaceState({ panel: initialPanel }, "", "#" + initialPanel);
 
   // Fetch summary statistics
-  fetch('/summary-statistics')
-    .then(r => r.json())
-    .then(data => {
-      const container = document.getElementById('workspace-summary');
+  fetch("/summary-statistics")
+    .then((r) => r.json())
+    .then((data) => {
+      const container = document.getElementById("workspace-summary");
       if (!container) return;
 
       if (data.success) {
@@ -1577,27 +1985,50 @@ function initWorkspace() {
         // Summary statistics table — pivoted: rows = features, columns = stats
         if (data.summary_statistics) {
           const features = Object.keys(data.summary_statistics);
-          const allStats = features.length > 0 ? Object.keys(data.summary_statistics[features[0]]) : [];
+          const allStats =
+            features.length > 0
+              ? Object.keys(data.summary_statistics[features[0]])
+              : [];
           // Preferred order
-          const preferredOrder = ['count', 'min', '25th percentile', '50th percentile', 'mean', '75th percentile', 'max', 'std'];
-          const statKeys = preferredOrder.filter(s => allStats.includes(s)).concat(allStats.filter(s => !preferredOrder.includes(s)));
+          const preferredOrder = [
+            "count",
+            "min",
+            "25th percentile",
+            "50th percentile",
+            "mean",
+            "75th percentile",
+            "max",
+            "std",
+          ];
+          const statKeys = preferredOrder
+            .filter((s) => allStats.includes(s))
+            .concat(allStats.filter((s) => !preferredOrder.includes(s)));
 
           html += '<div class="relative overflow-x-auto rounded-lg shadow-sm">';
-          html += '<table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">';
-          html += '<thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400"><tr>';
+          html +=
+            '<table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">';
+          html +=
+            '<thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400"><tr>';
           html += '<th scope="col" class="px-4 py-3">Feature</th>';
-          statKeys.forEach(s => { html += `<th scope="col" class="px-4 py-3 text-right">${s}</th>`; });
-          html += '</tr></thead><tbody>';
+          statKeys.forEach((s) => {
+            html += `<th scope="col" class="px-4 py-3 text-right">${s}</th>`;
+          });
+          html += "</tr></thead><tbody>";
 
           features.forEach((feat, i) => {
-            const stripe = i % 2 === 0 ? 'bg-white dark:bg-gray-800' : 'bg-gray-50 dark:bg-gray-700/50';
+            const stripe =
+              i % 2 === 0
+                ? "bg-white dark:bg-gray-800"
+                : "bg-gray-50 dark:bg-gray-700/50";
             html += `<tr class="${stripe} border-b dark:border-gray-700">`;
             html += `<td class="px-4 py-2 font-medium text-gray-900 dark:text-white whitespace-nowrap">${feat}</td>`;
-            statKeys.forEach(s => { html += `<td class="px-4 py-2 font-mono text-xs text-right">${data.summary_statistics[feat][s] ?? '—'}</td>`; });
-            html += '</tr>';
+            statKeys.forEach((s) => {
+              html += `<td class="px-4 py-2 font-mono text-xs text-right">${data.summary_statistics[feat][s] ?? "—"}</td>`;
+            });
+            html += "</tr>";
           });
 
-          html += '</tbody></table></div>';
+          html += "</tbody></table></div>";
         }
 
         container.innerHTML = html;
@@ -1610,63 +2041,70 @@ function initWorkspace() {
         container.innerHTML = `<p class="text-sm" style="color: var(--textColorSecondary);">Could not load summary: ${data.message}</p>`;
       }
     })
-    .catch(err => {
-      const container = document.getElementById('workspace-summary');
-      if (container) container.innerHTML = `<p class="text-sm" style="color: red;">Error loading summary: ${err.message}</p>`;
+    .catch((err) => {
+      const container = document.getElementById("workspace-summary");
+      if (container)
+        container.innerHTML = `<p class="text-sm" style="color: red;">Error loading summary: ${err.message}</p>`;
     });
 
   // Populate feature dropdowns via /feature-set (same as metric.js does)
-  fetch('/feature-set', { method: 'POST' })
-    .then(r => r.json())
-    .then(data => {
-      if (data.success && typeof populateWorkspaceDropdowns === 'function') {
+  fetch("/feature-set", { method: "POST" })
+    .then((r) => r.json())
+    .then((data) => {
+      if (data.success && typeof populateWorkspaceDropdowns === "function") {
         populateWorkspaceDropdowns(data);
       }
     })
-    .catch(err => console.error('Error fetching features:', err));
+    .catch((err) => console.error("Error fetching features:", err));
 
   // Feature relevance: disable target feature in checkbox lists
-  const targetDropdown = document.getElementById('all-features-dropdown-feature-relevance');
+  const targetDropdown = document.getElementById(
+    "all-features-dropdown-feature-relevance",
+  );
   if (targetDropdown) {
-    targetDropdown.addEventListener('change', function () {
+    targetDropdown.addEventListener("change", function () {
       const target = this.value;
       // In both cat and num checkbox containers, disable the checkbox matching the target
-      ['catFeaturesCheckbox1', 'numFeaturesCheckbox1'].forEach(containerId => {
-        const container = document.getElementById(containerId);
-        if (!container) return;
-        container.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-          if (cb.value === target) {
-            cb.checked = false;
-            cb.disabled = true;
-            cb.closest('label').style.opacity = '0.4';
-          } else {
-            cb.disabled = false;
-            cb.closest('label').style.opacity = '1';
-          }
-        });
-      });
+      ["catFeaturesCheckbox1", "numFeaturesCheckbox1"].forEach(
+        (containerId) => {
+          const container = document.getElementById(containerId);
+          if (!container) return;
+          container.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
+            if (cb.value === target) {
+              cb.checked = false;
+              cb.disabled = true;
+              cb.closest("label").style.opacity = "0.4";
+            } else {
+              cb.disabled = false;
+              cb.closest("label").style.opacity = "1";
+            }
+          });
+        },
+      );
     });
   }
 
   // Handle FAIR assessment file input UI
-  const fairFile = document.getElementById('fair-file');
-  const fairLabel = document.getElementById('fairFileLabel');
-  const fairIcon = document.getElementById('fairUploadIcon');
+  const fairFile = document.getElementById("fair-file");
+  const fairLabel = document.getElementById("fairFileLabel");
+  const fairIcon = document.getElementById("fairUploadIcon");
   if (fairFile && fairLabel) {
-    fairFile.addEventListener('change', () => {
+    fairFile.addEventListener("change", () => {
       if (fairFile.files.length) {
         fairLabel.textContent = fairFile.files[0].name;
         if (fairIcon) {
-          fairIcon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>';
-          fairIcon.classList.remove('text-gray-400');
-          fairIcon.classList.add('text-green-500');
+          fairIcon.innerHTML =
+            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>';
+          fairIcon.classList.remove("text-gray-400");
+          fairIcon.classList.add("text-green-500");
         }
       } else {
-        fairLabel.textContent = 'JSON metadata file';
+        fairLabel.textContent = "JSON metadata file";
         if (fairIcon) {
-          fairIcon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>';
-          fairIcon.classList.remove('text-green-500');
-          fairIcon.classList.add('text-gray-400');
+          fairIcon.innerHTML =
+            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>';
+          fairIcon.classList.remove("text-green-500");
+          fairIcon.classList.add("text-gray-400");
         }
       }
     });
@@ -1689,8 +2127,8 @@ function populateWorkspaceDropdowns(data) {
     if (!el) return;
     // Keep the first disabled option
     while (el.options.length > 1) el.remove(1);
-    features.forEach(f => {
-      const opt = document.createElement('option');
+    features.forEach((f) => {
+      const opt = document.createElement("option");
       opt.value = f;
       opt.textContent = f;
       el.appendChild(opt);
@@ -1704,21 +2142,24 @@ function populateWorkspaceDropdowns(data) {
   function fillCheckboxContainer(id, features, nameAttr) {
     const el = document.getElementById(id);
     if (!el) return;
-    el.innerHTML = '';
+    el.innerHTML = "";
 
     if (features.length === 0) {
-      el.innerHTML = '<p class="text-xs text-gray-400 dark:text-gray-500 py-2">No features available</p>';
+      el.innerHTML =
+        '<p class="text-xs text-gray-400 dark:text-gray-500 py-2">No features available</p>';
       return;
     }
 
     // Wrapper with max-height scroll
-    const wrapper = document.createElement('div');
-    wrapper.className = 'border border-gray-200 dark:border-gray-700 rounded-lg p-2 overflow-y-auto overflow-x-hidden';
-    wrapper.style.maxHeight = '300px';
+    const wrapper = document.createElement("div");
+    wrapper.className =
+      "border border-gray-200 dark:border-gray-700 rounded-lg p-2 overflow-y-auto overflow-x-hidden";
+    wrapper.style.maxHeight = "300px";
 
     // Select all / none controls
-    const controls = document.createElement('div');
-    controls.className = 'flex items-center gap-3 mb-2 pb-2 border-b border-gray-200 dark:border-gray-700';
+    const controls = document.createElement("div");
+    controls.className =
+      "flex items-center gap-3 mb-2 pb-2 border-b border-gray-200 dark:border-gray-700";
     controls.innerHTML = `
       <button type="button" class="text-xs text-blue-600 dark:text-blue-400 hover:underline cursor-pointer" onclick="toggleAllCheckboxes(this, '${id}', true)">Select all</button>
       <button type="button" class="text-xs text-gray-500 dark:text-gray-400 hover:underline cursor-pointer" onclick="toggleAllCheckboxes(this, '${id}', false)">Clear</button>
@@ -1727,22 +2168,26 @@ function populateWorkspaceDropdowns(data) {
     wrapper.appendChild(controls);
 
     // Chip grid
-    const grid = document.createElement('div');
-    grid.className = 'flex flex-wrap gap-1.5';
+    const grid = document.createElement("div");
+    grid.className = "flex flex-wrap gap-1.5";
 
-    features.forEach(f => {
-      const label = document.createElement('label');
-      label.className = 'inline-block px-3 py-1.5 rounded-md text-sm cursor-pointer transition-colors border border-gray-200 dark:border-gray-600 hover:border-blue-400 dark:hover:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:text-blue-700 dark:has-[:checked]:bg-blue-900/30 dark:has-[:checked]:border-blue-400 dark:has-[:checked]:text-blue-300';
-      label.style.cssText = 'max-width: 200px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;';
+    features.forEach((f) => {
+      const label = document.createElement("label");
+      label.className =
+        "inline-block px-3 py-1.5 rounded-md text-sm cursor-pointer transition-colors border border-gray-200 dark:border-gray-600 hover:border-blue-400 dark:hover:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:text-blue-700 dark:has-[:checked]:bg-blue-900/30 dark:has-[:checked]:border-blue-400 dark:has-[:checked]:text-blue-300";
+      label.style.cssText =
+        "max-width: 200px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;";
       label.title = f;
 
-      const cb = document.createElement('input');
-      cb.type = 'checkbox';
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
       cb.name = nameAttr;
       cb.value = f;
-      cb.style.cssText = 'width: 14px; height: 14px; min-width: 14px; vertical-align: middle; margin-right: 6px;';
-      cb.className = 'shrink-0 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:bg-gray-700 dark:border-gray-600';
-      cb.addEventListener('change', () => updateCheckboxCount(id));
+      cb.style.cssText =
+        "width: 14px; height: 14px; min-width: 14px; vertical-align: middle; margin-right: 6px;";
+      cb.className =
+        "shrink-0 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:bg-gray-700 dark:border-gray-600";
+      cb.addEventListener("change", () => updateCheckboxCount(id));
 
       label.appendChild(cb);
       label.appendChild(document.createTextNode(f));
@@ -1754,83 +2199,138 @@ function populateWorkspaceDropdowns(data) {
   }
 
   // Fairness dropdowns
-  fillDropdown('allFeaturesDropdownRepRate', allFeatures);
-  fillDropdown('allFeaturesDropdownStatRate1', allFeatures);
-  fillDropdown('allFeaturesDropdownStatRate2', allFeatures);
-  fillDropdown('allFeaturesDropdownCondDemoDis1', allFeatures);
-  fillDropdown('allFeaturesDropdownCondDemoDis2', allFeatures);
+  fillDropdown("allFeaturesDropdownRepRate", allFeatures);
+  fillDropdown("allFeaturesDropdownStatRate1", allFeatures);
+  fillDropdown("allFeaturesDropdownStatRate2", allFeatures);
+  fillDropdown("allFeaturesDropdownCondDemoDis1", allFeatures);
+  fillDropdown("allFeaturesDropdownCondDemoDis2", allFeatures);
 
   // Feature Relevance
-  fillDropdown('all-features-dropdown-feature-relevance', allFeatures);
-  fillCheckboxContainer('catFeaturesCheckbox1', catFeatures, 'categorical features for feature relevancy');
-  fillCheckboxContainer('numFeaturesCheckbox1', numFeatures, 'numerical features for feature relevancy');
+  fillDropdown("all-features-dropdown-feature-relevance", allFeatures);
+  fillCheckboxContainer(
+    "catFeaturesCheckbox1",
+    catFeatures,
+    "categorical features for feature relevancy",
+  );
+  fillCheckboxContainer(
+    "numFeaturesCheckbox1",
+    numFeatures,
+    "numerical features for feature relevancy",
+  );
 
   // Correlation Analysis (separate containers — unique IDs to avoid conflicts)
-  fillCheckboxContainer('corrCatFeaturesCheckbox', catFeatures, 'categorical features for correlation analysis');
-  fillCheckboxContainer('corrNumFeaturesCheckbox', numFeatures, 'numerical features for correlation analysis');
+  fillCheckboxContainer(
+    "corrCatFeaturesCheckbox",
+    catFeatures,
+    "categorical features for correlation analysis",
+  );
+  fillCheckboxContainer(
+    "corrNumFeaturesCheckbox",
+    numFeatures,
+    "numerical features for correlation analysis",
+  );
 
   // Privacy dropdowns
-  fillDropdown('allFeaturesDropdownMMS', allFeatures);
-  fillDropdown('allFeaturesDropdownMMM', allFeatures);
-  fillDropdown('lDiversitySensitiveDropdown', allFeatures);
-  fillDropdown('tClosenessSensitiveDropdown', allFeatures);
-  fillCheckboxContainer('numFeaturesCheckbox2', numFeatures, 'numerical features to add noise');
-  fillCheckboxContainer('catFeaturesCheckbox2', catFeatures, 'quasi identifiers to measure single attribute risk score');
-  fillCheckboxContainer('catFeaturesCheckbox3', catFeatures, 'quasi identifiers to measure multiple attribute risk score');
-  fillCheckboxContainer('entropyRiskQIsCheckbox', allFeatures, 'quasi identifiers for entropy risk');
-  fillCheckboxContainer('kAnonymityQIsCheckbox', allFeatures, 'quasi identifiers for k-anonymity');
-  fillCheckboxContainer('lDiversityQIsCheckbox', allFeatures, 'quasi identifiers for l-diversity');
-  fillCheckboxContainer('tClosenessQIsCheckbox', allFeatures, 'quasi identifiers for t-closeness');
+  fillDropdown("allFeaturesDropdownMMS", allFeatures);
+  fillDropdown("allFeaturesDropdownMMM", allFeatures);
+  fillDropdown("lDiversitySensitiveDropdown", allFeatures);
+  fillDropdown("tClosenessSensitiveDropdown", allFeatures);
+  fillCheckboxContainer(
+    "numFeaturesCheckbox2",
+    numFeatures,
+    "numerical features to add noise",
+  );
+  fillCheckboxContainer(
+    "catFeaturesCheckbox2",
+    catFeatures,
+    "quasi identifiers to measure single attribute risk score",
+  );
+  fillCheckboxContainer(
+    "catFeaturesCheckbox3",
+    catFeatures,
+    "quasi identifiers to measure multiple attribute risk score",
+  );
+  fillCheckboxContainer(
+    "entropyRiskQIsCheckbox",
+    allFeatures,
+    "quasi identifiers for entropy risk",
+  );
+  fillCheckboxContainer(
+    "kAnonymityQIsCheckbox",
+    allFeatures,
+    "quasi identifiers for k-anonymity",
+  );
+  fillCheckboxContainer(
+    "lDiversityQIsCheckbox",
+    allFeatures,
+    "quasi identifiers for l-diversity",
+  );
+  fillCheckboxContainer(
+    "tClosenessQIsCheckbox",
+    allFeatures,
+    "quasi identifiers for t-closeness",
+  );
 
   // Class Imbalance
-  fillDropdown('all-features-dropdown-class-imbalance', classImbalanceFeatures);
+  fillDropdown("all-features-dropdown-class-imbalance", classImbalanceFeatures);
 
   // HIPAA
-  fillCheckboxContainer('hipaa-identifiers-checkbox', allFeatures, 'HIPAA identifiers for HIPAA compliance');
+  fillCheckboxContainer(
+    "hipaa-identifiers-checkbox",
+    allFeatures,
+    "HIPAA identifiers for HIPAA compliance",
+  );
 
   // Distance metrics for class imbalance — render as chips + sync to hidden select
-  const distChips = document.getElementById('class-imbalance-distance-chips');
-  const distSelect = document.getElementById('class-imbalance-distance-dropdown');
+  const distChips = document.getElementById("class-imbalance-distance-chips");
+  const distSelect = document.getElementById(
+    "class-imbalance-distance-dropdown",
+  );
   if (distChips && distChips.children.length === 0) {
     const distances = [
-      { value: 'EU', label: 'Euclidean Distance', short: 'EU' },
-      { value: 'CH', label: 'Chi-Squared Distance', short: 'CH' },
-      { value: 'KL', label: 'KL Divergence', short: 'KL' },
-      { value: 'HE', label: 'Hellinger Distance', short: 'HE' },
-      { value: 'TV', label: 'Total Variation', short: 'TV' },
-      { value: 'CS', label: 'Cosine Similarity', short: 'CS' },
+      { value: "EU", label: "Euclidean Distance", short: "EU" },
+      { value: "CH", label: "Chi-Squared Distance", short: "CH" },
+      { value: "KL", label: "KL Divergence", short: "KL" },
+      { value: "HE", label: "Hellinger Distance", short: "HE" },
+      { value: "TV", label: "Total Variation", short: "TV" },
+      { value: "CS", label: "Cosine Similarity", short: "CS" },
     ];
 
     // Also populate hidden select for form submission
     if (distSelect) {
-      distances.forEach(d => {
-        const opt = document.createElement('option');
+      distances.forEach((d) => {
+        const opt = document.createElement("option");
         opt.value = d.value;
         opt.textContent = d.label;
         distSelect.appendChild(opt);
       });
     }
 
-    distances.forEach(d => {
-      const label = document.createElement('label');
-      label.className = 'inline-flex items-center px-3 py-1.5 rounded-md text-sm cursor-pointer transition-colors border border-gray-200 dark:border-gray-600 hover:border-blue-400 dark:hover:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:text-blue-700 dark:has-[:checked]:bg-blue-900/30 dark:has-[:checked]:border-blue-400 dark:has-[:checked]:text-blue-300';
+    distances.forEach((d) => {
+      const label = document.createElement("label");
+      label.className =
+        "inline-flex items-center px-3 py-1.5 rounded-md text-sm cursor-pointer transition-colors border border-gray-200 dark:border-gray-600 hover:border-blue-400 dark:hover:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:text-blue-700 dark:has-[:checked]:bg-blue-900/30 dark:has-[:checked]:border-blue-400 dark:has-[:checked]:text-blue-300";
 
-      const cb = document.createElement('input');
-      cb.type = 'checkbox';
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
       cb.value = d.value;
-      cb.className = 'w-3.5 h-3.5 shrink-0 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:bg-gray-700 dark:border-gray-600';
-      cb.style.marginRight = '8px';
+      cb.className =
+        "w-3.5 h-3.5 shrink-0 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:bg-gray-700 dark:border-gray-600";
+      cb.style.marginRight = "8px";
       // Sync checkbox to hidden select
-      cb.addEventListener('change', () => {
+      cb.addEventListener("change", () => {
         if (distSelect) {
-          Array.from(distSelect.options).forEach(opt => {
-            opt.selected = distChips.querySelector(`input[value="${opt.value}"]`)?.checked || false;
+          Array.from(distSelect.options).forEach((opt) => {
+            opt.selected =
+              distChips.querySelector(`input[value="${opt.value}"]`)?.checked ||
+              false;
           });
         }
       });
 
-      const text = document.createElement('span');
-      text.className = 'select-none text-gray-700 dark:text-gray-300 whitespace-nowrap';
+      const text = document.createElement("span");
+      text.className =
+        "select-none text-gray-700 dark:text-gray-300 whitespace-nowrap";
       text.textContent = `${d.short} — ${d.label}`;
 
       label.appendChild(cb);
@@ -1838,4 +2338,252 @@ function populateWorkspaceDropdowns(data) {
       distChips.appendChild(label);
     });
   }
+}
+
+// ==================== LLM Explanation ====================
+
+/**
+ * Request an AI explanation for a metric result from the configured LLM.
+ * Inserts a spinner, then replaces it with the explanation callout.
+ */
+/**
+ * Render an LLM explanation callout into a container element.
+ */
+function _renderLLMCallout(container, explanation, model) {
+  const modelTag = model
+    ? `<span class="ml-2 font-normal normal-case tracking-normal text-purple-400 dark:text-purple-500">(${model})</span>`
+    : "";
+  container.innerHTML = `
+    <div class="flex items-start gap-2.5 p-4 text-sm rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-900/20">
+      <svg class="w-5 h-5 shrink-0 mt-0.5 text-purple-400 dark:text-purple-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"/></svg>
+      <div>
+        <div class="text-xs font-semibold uppercase tracking-wide text-purple-500 dark:text-purple-400 mb-1">AI Explanation${modelTag}</div>
+        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">${explanation}</p>
+      </div>
+    </div>`;
+}
+
+function requestLLMExplanation(
+  containerId,
+  metricName,
+  description,
+  visualizations,
+  scores,
+) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  // Show loading spinner
+  container.innerHTML = `
+    <div class="flex items-center gap-2 p-3 mt-2 text-sm text-purple-600 dark:text-purple-400">
+      <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+      </svg>
+      Generating AI explanation...
+    </div>`;
+
+  // Get the first visualization base64 (strip data: prefix for the API)
+  let vizBase64 = "";
+  if (visualizations && visualizations.length > 0) {
+    const src = visualizations[0].src || "";
+    vizBase64 = src.startsWith("data:") ? src.split(",")[1] || "" : src;
+  }
+
+  // Build scores summary — strip large values (like base64 blobs)
+  let scoresData = null;
+  if (scores && Object.keys(scores).length > 0) {
+    scoresData = {};
+    for (const [k, v] of Object.entries(scores)) {
+      if (typeof v === "string" && v.length > 500) continue;
+      scoresData[k] = v;
+    }
+  }
+
+  fetch("/llm/explain", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      metric_name: metricName,
+      description: description,
+      visualization: vizBase64,
+      scores: scoresData,
+    }),
+  })
+    .then((r) => r.json())
+    .then((data) => {
+      if (data.explanation) {
+        _renderLLMCallout(container, data.explanation, data.model);
+
+        // Cache the explanation server-side for restore on panel revisit
+        const cacheMetric = _panelCacheMap[activePanel];
+        if (cacheMetric) {
+          fetch("/llm/cache-explanation", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              metric_name: cacheMetric,
+              result_type: metricName,
+              explanation: data.explanation,
+              model: data.model || "",
+            }),
+          }).catch(() => {});
+        }
+      } else {
+        const errMsg = data.error || "No explanation returned";
+        container.innerHTML = `
+          <div class="flex items-center gap-2 p-3 text-sm text-yellow-700 dark:text-yellow-400 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800">
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/></svg>
+            AI explanation unavailable: ${errMsg}
+          </div>`;
+        debugLog("LLM explanation unavailable:", errMsg);
+      }
+    })
+    .catch((err) => {
+      container.innerHTML = `
+        <div class="flex items-center gap-2 p-3 text-sm text-yellow-700 dark:text-yellow-400 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800">
+          <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/></svg>
+          AI explanation error: ${err.message || err}
+        </div>`;
+      debugLog("LLM explanation error:", err);
+    });
+}
+
+// ==================== LLM Settings ====================
+
+function openLLMSettings() {
+  const modal = document.getElementById("llm-settings-modal");
+  if (modal) modal.classList.remove("hidden");
+}
+
+function closeLLMSettings() {
+  const modal = document.getElementById("llm-settings-modal");
+  if (modal) modal.classList.add("hidden");
+}
+
+function _getLLMFormValues() {
+  const apiBase = document.getElementById("llm-api-base").value.trim();
+  const apiKey = document.getElementById("llm-api-key").value.trim();
+  const model = document.getElementById("llm-model").value.trim();
+  const temp = parseFloat(document.getElementById("llm-temperature").value);
+  return {
+    api_base: apiBase || "https://api.openai.com/v1",
+    api_key: apiKey,
+    model: model || "gpt-4o-mini",
+    temperature: isNaN(temp) ? 0.5 : temp,
+  };
+}
+
+function testLLMConnection() {
+  const statusEl = document.getElementById("llm-settings-status");
+  const testBtn = document.getElementById("llm-test-btn");
+  const saveBtn = document.getElementById("llm-save-btn");
+  const config = _getLLMFormValues();
+
+  if (
+    !config.api_key ||
+    config.api_key === "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"
+  ) {
+    if (statusEl) {
+      statusEl.className = "mt-3 text-sm text-red-600 dark:text-red-400";
+      statusEl.textContent = "Please enter your API key.";
+      statusEl.classList.remove("hidden");
+    }
+    return;
+  }
+
+  // Disable buttons during test
+  if (testBtn) {
+    testBtn.disabled = true;
+    testBtn.textContent = "Testing...";
+  }
+  if (saveBtn) saveBtn.disabled = true;
+
+  fetch("/llm/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(config),
+  })
+    .then((r) => r.json().then((data) => ({ ok: r.ok, data })))
+    .then(({ ok, data }) => {
+      if (testBtn) {
+        testBtn.disabled = false;
+        testBtn.textContent = "Test";
+      }
+      if (ok && data.success) {
+        if (saveBtn) saveBtn.disabled = false;
+        if (statusEl) {
+          statusEl.className =
+            "mt-3 text-sm text-green-600 dark:text-green-400";
+          statusEl.textContent = "Connection successful. You can now save.";
+          statusEl.classList.remove("hidden");
+        }
+      } else {
+        if (saveBtn) saveBtn.disabled = true;
+        if (statusEl) {
+          statusEl.className = "mt-3 text-sm text-red-600 dark:text-red-400";
+          statusEl.textContent =
+            "Test failed: " + (data.error || "Unknown error");
+          statusEl.classList.remove("hidden");
+        }
+      }
+    })
+    .catch((err) => {
+      if (testBtn) {
+        testBtn.disabled = false;
+        testBtn.textContent = "Test";
+      }
+      if (saveBtn) saveBtn.disabled = true;
+      if (statusEl) {
+        statusEl.className = "mt-3 text-sm text-red-600 dark:text-red-400";
+        statusEl.textContent = "Connection error: " + err.message;
+        statusEl.classList.remove("hidden");
+      }
+    });
+}
+
+function saveLLMSettings() {
+  const statusEl = document.getElementById("llm-settings-status");
+  const config = _getLLMFormValues();
+
+  fetch("/llm/configure", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(config),
+  })
+    .then((r) => r.json())
+    .then((data) => {
+      if (data.success) {
+        window.AIDRIN_LLM_ENABLED = true;
+        if (statusEl) {
+          statusEl.className =
+            "mt-3 text-sm text-green-600 dark:text-green-400";
+          statusEl.textContent =
+            "Settings saved. AI explanations are now enabled.";
+          statusEl.classList.remove("hidden");
+        }
+        setTimeout(() => closeLLMSettings(), 1500);
+      } else {
+        if (statusEl) {
+          statusEl.className = "mt-3 text-sm text-red-600 dark:text-red-400";
+          statusEl.textContent = data.error || "Failed to save settings.";
+          statusEl.classList.remove("hidden");
+        }
+      }
+    })
+    .catch((err) => {
+      if (statusEl) {
+        statusEl.className = "mt-3 text-sm text-red-600 dark:text-red-400";
+        statusEl.textContent = "Connection error: " + err.message;
+        statusEl.classList.remove("hidden");
+      }
+    });
+}
+
+function disconnectLLM() {
+  fetch("/llm/disconnect", { method: "POST" }).then(() => {
+    window.AIDRIN_LLM_ENABLED = false;
+    closeLLMSettings();
+    showToast("LLM disconnected", "info");
+  });
 }

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -1,6 +1,8 @@
 // Debug logging — set to true to enable console output
 const AIDRIN_DEBUG = localStorage.getItem("aidrin_debug") === "true";
-function debugLog(...args) { if (AIDRIN_DEBUG) debugLog("[aidrin]", ...args); }
+function debugLog(...args) {
+  if (AIDRIN_DEBUG) debugLog("[aidrin]", ...args);
+}
 
 function togglePillarDropdown(id) {
   const container = document.getElementById(id); //
@@ -27,13 +29,15 @@ function uploadForm() {
 
   // Check if file type is selected
   if (!fileTypeSelector.value) {
-    if (typeof showToast === 'function') showToast("Please select a file type first", "error");
+    if (typeof showToast === "function")
+      showToast("Please select a file type first", "error");
     return;
   }
 
   // Check if file is selected
   if (!fileInput.files || fileInput.files.length === 0) {
-    if (typeof showToast === 'function') showToast("Please select a file to upload", "error");
+    if (typeof showToast === "function")
+      showToast("Please select a file to upload", "error");
     return;
   }
 
@@ -43,6 +47,14 @@ function uploadForm() {
 
 //to clear
 function clearFile() {
+  // Clear saved form states
+  try {
+    Object.keys(sessionStorage)
+      .filter((k) => k.startsWith("aidrin_form_"))
+      .forEach((k) => sessionStorage.removeItem(k));
+  } catch (e) {
+    /* ignore */
+  }
   fetch("/clear", {
     method: "POST",
   })
@@ -62,7 +74,7 @@ function clearFile() {
 function updateFileInputBasedOnType(
   fileTypeElement,
   fileInput,
-  fileUploadMessage
+  fileUploadMessage,
 ) {
   const fileType = fileTypeElement.value;
   //if a filetype is present, set to that filetype only, otherwise disable
@@ -282,21 +294,15 @@ function submitForm() {
   // Get the values of the checkboxes and concatenate them with a comma
   var checkboxValues = Array.from(formData.getAll("checkboxValues")).join(",");
   var numFeaCheckboxValues = Array.from(
-    formData.getAll("numerical features for feature relevancy")
+    formData.getAll("numerical features for feature relevancy"),
   ).join(",");
   var catFeaCheckboxValues = Array.from(
-    formData.getAll("categorical features for feature relevancy")
+    formData.getAll("categorical features for feature relevancy"),
   ).join(",");
   // Add the concatenated checkbox values to the form data
   formData.set("correlation columns", checkboxValues);
-  formData.set(
-    "numerical features",
-    numFeaCheckboxValues
-  );
-  formData.set(
-    "categorical features",
-    catFeaCheckboxValues
-  );
+  formData.set("numerical features", numFeaCheckboxValues);
+  formData.set("categorical features", catFeaCheckboxValues);
 
   // Note: We don't need to modify the quasi-identifier fields as they should remain as lists
   // The backend will handle both string and list formats
@@ -333,30 +339,44 @@ function submitForm() {
         } else {
           openErrorPopup(
             "Invalid Request",
-            "Input Feature and Target Feature cannot be the same"
+            "Input Feature and Target Feature cannot be the same",
           );
         }
-
       }
 
       // Add validation for feature relevance form
       if (data.trigger === "validationError") {
-        openErrorPopup("Validation Error", data.error || "Please check your input and try again.");
+        openErrorPopup(
+          "Validation Error",
+          data.error || "Please check your input and try again.",
+        );
       }
 
       // Function to validate feature relevance form
       function validateFeatureRelevanceForm() {
-        const catFeatures = document.querySelectorAll('input[name="categorical features for feature relevancy"]:checked');
-        const numFeatures = document.querySelectorAll('input[name="numerical features for feature relevancy"]:checked');
-        const targetFeature = document.querySelector('select[name="target for feature relevance"]').value;
+        const catFeatures = document.querySelectorAll(
+          'input[name="categorical features for feature relevancy"]:checked',
+        );
+        const numFeatures = document.querySelectorAll(
+          'input[name="numerical features for feature relevancy"]:checked',
+        );
+        const targetFeature = document.querySelector(
+          'select[name="target for feature relevance"]',
+        ).value;
 
         if (catFeatures.length === 0 && numFeatures.length === 0) {
-          openErrorPopup("Validation Error", "Please select at least one categorical or numerical feature for analysis.");
+          openErrorPopup(
+            "Validation Error",
+            "Please select at least one categorical or numerical feature for analysis.",
+          );
           return false;
         }
 
         if (!targetFeature) {
-          openErrorPopup("Validation Error", "Please select a target feature for analysis.");
+          openErrorPopup(
+            "Validation Error",
+            "Please select a target feature for analysis.",
+          );
           return false;
         }
 
@@ -403,7 +423,7 @@ function submitForm() {
             "Validation/Processing error in",
             type,
             ":",
-            data[type]["Error"]
+            data[type]["Error"],
           );
 
           // Show error popup immediately for all error types
@@ -412,12 +432,12 @@ function submitForm() {
             openErrorPopup(errorType, data[type]["Error"]);
           } else if (type === "Single attribute risk scoring") {
             const errorType = getSingleAttributeRiskErrorType(
-              data[type]["Error"]
+              data[type]["Error"],
             );
             openErrorPopup(errorType, data[type]["Error"]);
           } else if (type === "Multiple attribute risk scoring") {
             const errorType = getMultipleAttributeRiskErrorType(
-              data[type]["Error"]
+              data[type]["Error"],
             );
             openErrorPopup(errorType, data[type]["Error"]);
           } else if (type === "Entropy Risk") {
@@ -441,18 +461,16 @@ function submitForm() {
 
       // Debug: Log the entire data structure to see what we're receiving
       debugLog("DEBUG: Full data structure received:", data);
-      debugLog(
-        "DEBUG: Checking for Single attribute risk scoring errors..."
-      );
+      debugLog("DEBUG: Checking for Single attribute risk scoring errors...");
       if (data["Single attribute risk scoring"]) {
         debugLog(
           "DEBUG: Single attribute risk scoring data:",
-          data["Single attribute risk scoring"]
+          data["Single attribute risk scoring"],
         );
         if (data["Single attribute risk scoring"]["Error"]) {
           debugLog(
             "DEBUG: Found error in Single attribute risk scoring:",
-            data["Single attribute risk scoring"]["Error"]
+            data["Single attribute risk scoring"]["Error"],
           );
         } else {
           debugLog("DEBUG: No error found in Single attribute risk scoring");
@@ -464,181 +482,217 @@ function submitForm() {
       visualizationTypes.forEach(function (type) {
         debugLog("Checking type:", type);
         if (isKeyPresentAndDefined(data, type)) {
-            if (type === "Custom Metric Evaluation") {
-                // Handle Custom Metric Evaluation (from HEAD)
-                debugLog("Adding Custom Metric Evaluation:", type);
-                var jsonData = JSON.stringify(data[type], null, 2); // Pretty-print JSON
-                visualizationContent.push({
-                    title: type,
-                    jsonData: jsonData,
-                    isCustomMetric: true,
-                    riskScore: "N/A",
-                    value: "N/A",
-                    downloadUrl: data[type].apply_remedy || null
-                });
-            } else if (type === "HIPAA Compliance Evaluation") {
-                var jsonData = JSON.stringify(data[type], null, 2); // Pretty-print JSON
-                var description = data[type]["Description"] || "No description provided.";
-                visualizationContent.push({
-                    title: type,
-                    jsonData: jsonData,
-                    isCustomMetric: true,
-                    description: description,
-                    riskScore: "N/A",
-                    value: "N/A",
-                });
-            } else if (data[type]["is_async"]) {
-                // Handle async tasks (from develop)
-                debugLog("Adding async task placeholder:", type);
-                var title = type;
-                var jsonData = JSON.stringify(data);
-                visualizationContent.push({
-                    image: "",
-                    riskScore: "N/A",
-                    riskLevel: null,
-                    riskColor: null,
-                    value: "N/A",
-                    description: "",
-                    interpretation: "",
-                    title: title,
-                    jsonData: jsonData,
-                    hasError: false,
-                    isAsync: true,
-                    taskId: data[type]["task_id"],
-                    cacheKey: data[type]["cache_key"],
-                });
-                debugLog("Starting polling for task:", data[type]["task_id"], "for metric:", type);
-                pollAsyncTask(data[type]["task_id"], data[type]["cache_key"], type);
-            } else if (isKeyPresentAndDefined(data[type], type + " Visualization")) {
-                debugLog("Adding visualization:", type);
-                var image = data[type][type + " Visualization"];
-                // Ensure image is a string
-                if (typeof image !== "string") {
-                    image = image ? String(image) : "";
-                }
-                // Handle specific field names for privacy metrics and class imbalance
-                var value = "N/A";
-                if (type === "k-Anonymity" && data[type]["k-Value"] !== undefined) {
-                    value = data[type]["k-Value"];
-                } else if (type === "l-Diversity" && data[type]["l-Value"] !== undefined) {
-                    value = data[type]["l-Value"];
-                } else if (type === "t-Closeness" && data[type]["t-Value"] !== undefined) {
-                    value = data[type]["t-Value"];
-                } else if (type === "Entropy Risk" && data[type]["Entropy-Value"] !== undefined) {
-                    value = data[type]["Entropy-Value"];
-                } else if (
-                    type === "Class Imbalance" &&
-                    data[type]["Imbalance degree"] &&
-                    data[type]["Imbalance degree"]["Imbalance Degree score"] !== undefined
-                ) {
-                    value = data[type]["Imbalance degree"]["Imbalance Degree score"];
-                } else if (data[type]["Value"] !== undefined) {
-                    value = data[type]["Value"];
-                }
-                // Handle specific field names for privacy metrics descriptions and class imbalance
-                var description = "";
-                var interpretation = "";
-                if (type === "k-Anonymity" || type === "l-Diversity" || type === "t-Closeness" || type === "Entropy Risk") {
-                    description = data[type]["Description"] || "";
-                    interpretation = data[type]["Graph interpretation"] || "";
-                } else if (type === "Class Imbalance") {
-                    description = data[type]["Description"] || "";
-                    interpretation = data[type]["Imbalance degree"] && data[type]["Imbalance degree"]["Description"] ? data[type]["Imbalance degree"]["Description"] : "";
-                } else {
-                    description = data[type]["Description"] || "";
-                    interpretation = data[type]["Graph interpretation"] || "";
-                }
-                var riskScore = data[type]["Risk Score"] || "N/A";
-                var riskLevel = data[type]["Risk Level"] || null;
-                var riskColor = data[type]["Risk Color"] || null;
-                var title = type;
-                var jsonData = JSON.stringify(data);
-
-                // Check if there's an error or if the image is empty
-                if (data[type]["Error"]) {
-                    debugLog("Error in", type, ":", data[type]["Error"]);
-                    // Enhanced error handling for specific metrics (from develop)
-                    let errorType = "Error";
-                    let isSpecificError = false;
-                    let errorMetricFlag = {};
-
-                    if (type === "DP Statistics") {
-                        errorType = getDPStatisticsErrorType(data[type]["Error"]);
-                        isSpecificError = true;
-                        errorMetricFlag.isDPStatistics = true;
-                    } else if (type === "Single attribute risk scoring") {
-                        errorType = getSingleAttributeRiskErrorType(data[type]["Error"]);
-                        isSpecificError = true;
-                        errorMetricFlag.isSingleAttributeRisk = true;
-                    } else if (type === "Multiple attribute risk scoring") {
-                        errorType = getMultipleAttributeRiskErrorType(data[type]["Error"]);
-                        isSpecificError = true;
-                        errorMetricFlag.isMultipleAttributeRisk = true;
-                    } else if (type === "Entropy Risk") {
-                        errorType = getEntropyRiskErrorType(data[type]["Error"]);
-                        isSpecificError = true;
-                        errorMetricFlag.isEntropyRisk = true;
-                    } else if (type === "k-Anonymity") {
-                        errorType = getKAnonymityErrorType(data[type]["Error"]);
-                        isSpecificError = true;
-                        errorMetricFlag.isKAnonymity = true;
-                    } else if (type === "l-Diversity") {
-                        errorType = getLDiversityErrorType(data[type]["Error"]);
-                        isSpecificError = true;
-                        errorMetricFlag.isLDiversity = true;
-                    } else if (type === "t-Closeness") {
-                        errorType = getTClosenessErrorType(data[type]["Error"]);
-                        isSpecificError = true;
-                        errorMetricFlag.isTCloseness = true;
-                    } else if (type === "Class Imbalance") {
-                        errorType = getClassImbalanceErrorType(data[type]["Error"]);
-                        isSpecificError = true;
-                        errorMetricFlag.isClassImbalance = true;
-                    }
-
-                    // Show error popup immediately
-                    openErrorPopup(errorType, data[type]["Error"]);
-
-                    visualizationContent.push({
-                        image: "",
-                        riskScore: "N/A",
-                        riskLevel: null,
-                        riskColor: null,
-                        value: "N/A",
-                        description: "",
-                        interpretation: "",
-                        title: title,
-                        jsonData: jsonData,
-                        hasError: true,
-                        ...errorMetricFlag,
-                        errorDetails: {
-                            errorMessage: data[type]["Error"],
-                            errorType: errorType,
-                        },
-                    });
-                } else if (image && image.trim() !== "") {
-                    visualizationContent.push({
-                        image: image,
-                        riskScore: riskScore,
-                        riskLevel: riskLevel,
-                        riskColor: riskColor,
-                        value: value,
-                        description: description,
-                        interpretation: interpretation,
-                        title: title,
-                        jsonData: jsonData,
-                        hasError: false,
-                    });
-                } else {
-                    debugLog("Empty visualization for:", type);
-                }
-            } else {
-                debugLog("Missing visualization key for:", type, "Expected:", type + " Visualization");
+          if (type === "Custom Metric Evaluation") {
+            // Handle Custom Metric Evaluation (from HEAD)
+            debugLog("Adding Custom Metric Evaluation:", type);
+            var jsonData = JSON.stringify(data[type], null, 2); // Pretty-print JSON
+            visualizationContent.push({
+              title: type,
+              jsonData: jsonData,
+              isCustomMetric: true,
+              riskScore: "N/A",
+              value: "N/A",
+              downloadUrl: data[type].apply_remedy || null,
+            });
+          } else if (type === "HIPAA Compliance Evaluation") {
+            var jsonData = JSON.stringify(data[type], null, 2); // Pretty-print JSON
+            var description =
+              data[type]["Description"] || "No description provided.";
+            visualizationContent.push({
+              title: type,
+              jsonData: jsonData,
+              isCustomMetric: true,
+              description: description,
+              riskScore: "N/A",
+              value: "N/A",
+            });
+          } else if (data[type]["is_async"]) {
+            // Handle async tasks (from develop)
+            debugLog("Adding async task placeholder:", type);
+            var title = type;
+            var jsonData = JSON.stringify(data);
+            visualizationContent.push({
+              image: "",
+              riskScore: "N/A",
+              riskLevel: null,
+              riskColor: null,
+              value: "N/A",
+              description: "",
+              interpretation: "",
+              title: title,
+              jsonData: jsonData,
+              hasError: false,
+              isAsync: true,
+              taskId: data[type]["task_id"],
+              cacheKey: data[type]["cache_key"],
+            });
+            debugLog(
+              "Starting polling for task:",
+              data[type]["task_id"],
+              "for metric:",
+              type,
+            );
+            pollAsyncTask(data[type]["task_id"], data[type]["cache_key"], type);
+          } else if (
+            isKeyPresentAndDefined(data[type], type + " Visualization")
+          ) {
+            debugLog("Adding visualization:", type);
+            var image = data[type][type + " Visualization"];
+            // Ensure image is a string
+            if (typeof image !== "string") {
+              image = image ? String(image) : "";
             }
+            // Handle specific field names for privacy metrics and class imbalance
+            var value = "N/A";
+            if (type === "k-Anonymity" && data[type]["k-Value"] !== undefined) {
+              value = data[type]["k-Value"];
+            } else if (
+              type === "l-Diversity" &&
+              data[type]["l-Value"] !== undefined
+            ) {
+              value = data[type]["l-Value"];
+            } else if (
+              type === "t-Closeness" &&
+              data[type]["t-Value"] !== undefined
+            ) {
+              value = data[type]["t-Value"];
+            } else if (
+              type === "Entropy Risk" &&
+              data[type]["Entropy-Value"] !== undefined
+            ) {
+              value = data[type]["Entropy-Value"];
+            } else if (
+              type === "Class Imbalance" &&
+              data[type]["Imbalance degree"] &&
+              data[type]["Imbalance degree"]["Imbalance Degree score"] !==
+                undefined
+            ) {
+              value = data[type]["Imbalance degree"]["Imbalance Degree score"];
+            } else if (data[type]["Value"] !== undefined) {
+              value = data[type]["Value"];
+            }
+            // Handle specific field names for privacy metrics descriptions and class imbalance
+            var description = "";
+            var interpretation = "";
+            if (
+              type === "k-Anonymity" ||
+              type === "l-Diversity" ||
+              type === "t-Closeness" ||
+              type === "Entropy Risk"
+            ) {
+              description = data[type]["Description"] || "";
+              interpretation = data[type]["Graph interpretation"] || "";
+            } else if (type === "Class Imbalance") {
+              description = data[type]["Description"] || "";
+              interpretation =
+                data[type]["Imbalance degree"] &&
+                data[type]["Imbalance degree"]["Description"]
+                  ? data[type]["Imbalance degree"]["Description"]
+                  : "";
+            } else {
+              description = data[type]["Description"] || "";
+              interpretation = data[type]["Graph interpretation"] || "";
+            }
+            var riskScore = data[type]["Risk Score"] || "N/A";
+            var riskLevel = data[type]["Risk Level"] || null;
+            var riskColor = data[type]["Risk Color"] || null;
+            var title = type;
+            var jsonData = JSON.stringify(data);
+
+            // Check if there's an error or if the image is empty
+            if (data[type]["Error"]) {
+              debugLog("Error in", type, ":", data[type]["Error"]);
+              // Enhanced error handling for specific metrics (from develop)
+              let errorType = "Error";
+              let isSpecificError = false;
+              let errorMetricFlag = {};
+
+              if (type === "DP Statistics") {
+                errorType = getDPStatisticsErrorType(data[type]["Error"]);
+                isSpecificError = true;
+                errorMetricFlag.isDPStatistics = true;
+              } else if (type === "Single attribute risk scoring") {
+                errorType = getSingleAttributeRiskErrorType(
+                  data[type]["Error"],
+                );
+                isSpecificError = true;
+                errorMetricFlag.isSingleAttributeRisk = true;
+              } else if (type === "Multiple attribute risk scoring") {
+                errorType = getMultipleAttributeRiskErrorType(
+                  data[type]["Error"],
+                );
+                isSpecificError = true;
+                errorMetricFlag.isMultipleAttributeRisk = true;
+              } else if (type === "Entropy Risk") {
+                errorType = getEntropyRiskErrorType(data[type]["Error"]);
+                isSpecificError = true;
+                errorMetricFlag.isEntropyRisk = true;
+              } else if (type === "k-Anonymity") {
+                errorType = getKAnonymityErrorType(data[type]["Error"]);
+                isSpecificError = true;
+                errorMetricFlag.isKAnonymity = true;
+              } else if (type === "l-Diversity") {
+                errorType = getLDiversityErrorType(data[type]["Error"]);
+                isSpecificError = true;
+                errorMetricFlag.isLDiversity = true;
+              } else if (type === "t-Closeness") {
+                errorType = getTClosenessErrorType(data[type]["Error"]);
+                isSpecificError = true;
+                errorMetricFlag.isTCloseness = true;
+              } else if (type === "Class Imbalance") {
+                errorType = getClassImbalanceErrorType(data[type]["Error"]);
+                isSpecificError = true;
+                errorMetricFlag.isClassImbalance = true;
+              }
+
+              // Show error popup immediately
+              openErrorPopup(errorType, data[type]["Error"]);
+
+              visualizationContent.push({
+                image: "",
+                riskScore: "N/A",
+                riskLevel: null,
+                riskColor: null,
+                value: "N/A",
+                description: "",
+                interpretation: "",
+                title: title,
+                jsonData: jsonData,
+                hasError: true,
+                ...errorMetricFlag,
+                errorDetails: {
+                  errorMessage: data[type]["Error"],
+                  errorType: errorType,
+                },
+              });
+            } else if (image && image.trim() !== "") {
+              visualizationContent.push({
+                image: image,
+                riskScore: riskScore,
+                riskLevel: riskLevel,
+                riskColor: riskColor,
+                value: value,
+                description: description,
+                interpretation: interpretation,
+                title: title,
+                jsonData: jsonData,
+                hasError: false,
+              });
+            } else {
+              debugLog("Empty visualization for:", type);
+            }
+          } else {
+            debugLog(
+              "Missing visualization key for:",
+              type,
+              "Expected:",
+              type + " Visualization",
+            );
+          }
         } else {
-            debugLog("Type not found in data:", type);
+          debugLog("Type not found in data:", type);
         }
-    });
+      });
       // Boolean flag to track if heading has been added
       var headingAdded = false;
 
@@ -666,15 +720,15 @@ function submitForm() {
 
             // Add a download button if apply_remedy exists
             if (content.downloadUrl) {
-                visualizationHtml += `
+              visualizationHtml += `
                 <a href="${content.downloadUrl}" download class="animated-button" style="margin-top: 10px; display: inline-block;">
                     Download Remedied Dataset
                 </a>`;
             }
           } else if (content.isAsync) {
-              // Handle async task placeholder (from develop)
-              const asyncId = `async-${content.taskId.replace(/[^a-zA-Z0-9]/g, "")}`;
-              visualizationHtml += `<div class="async-task-status"
+            // Handle async task placeholder (from develop)
+            const asyncId = `async-${content.taskId.replace(/[^a-zA-Z0-9]/g, "")}`;
+            visualizationHtml += `<div class="async-task-status"
                           data-task-id="${content.taskId}"
                           data-cache-key="${content.cacheKey}"
                           data-metric-name="${content.title}"
@@ -698,9 +752,9 @@ function submitForm() {
                           </style>
                       </div>`;
           } else if (content.hasError) {
-              // Enhanced error handling (from develop)
-              if (content.isDPStatistics) {
-                  visualizationHtml += `
+            // Enhanced error handling (from develop)
+            if (content.isDPStatistics) {
+              visualizationHtml += `
                       <div class="error-container" style="text-align: center; padding: 20px; border: 2px solid #d32f2f; border-radius: 8px; background-color: #ffebee; margin-bottom: 20px;">
                           <div style="color: #d32f2f; margin-bottom: 15px;">
                               <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#d32f2f" style="margin-bottom: 10px;">
@@ -717,8 +771,8 @@ function submitForm() {
                               </p>
                           </div>
                       </div>`;
-              } else if (content.isSingleAttributeRisk) {
-                  visualizationHtml += `
+            } else if (content.isSingleAttributeRisk) {
+              visualizationHtml += `
                       <div class="error-container" style="text-align: center; padding: 20px; border: 2px solid #d32f2f; border-radius: 8px; background-color: #ffebee; margin-bottom: 20px;">
                           <div style="color: #d32f2f; margin-bottom: 15px;">
                               <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#d32f2f" style="margin-bottom: 10px;">
@@ -735,8 +789,8 @@ function submitForm() {
                               </p>
                           </div>
                       </div>`;
-              } else if (content.isMultipleAttributeRisk) {
-                  visualizationHtml += `
+            } else if (content.isMultipleAttributeRisk) {
+              visualizationHtml += `
                       <div class="error-container" style="text-align: center; padding: 20px; border: 2px solid #d32f2f; border-radius: 8px; background-color: #ffebee; margin-bottom: 20px;">
                           <div style="color: #d32f2f; margin-bottom: 15px;">
                               <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#d32f2f" style="margin-bottom: 10px;">
@@ -753,8 +807,8 @@ function submitForm() {
                               </p>
                           </div>
                       </div>`;
-              } else if (content.isEntropyRisk) {
-                  visualizationHtml += `
+            } else if (content.isEntropyRisk) {
+              visualizationHtml += `
                       <div class="error-container" style="text-align: center; padding: 20px; border: 2px solid #d32f2f; border-radius: 8px; background-color: #ffebee; margin-bottom: 20px;">
                           <div style="color: #d32f2f; margin-bottom: 15px;">
                               <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#d32f2f" style="margin-bottom: 10px;">
@@ -771,8 +825,8 @@ function submitForm() {
                               </p>
                           </div>
                       </div>`;
-              } else if (content.isKAnonymity) {
-                  visualizationHtml += `
+            } else if (content.isKAnonymity) {
+              visualizationHtml += `
                       <div class="error-container" style="text-align: center; padding: 20px; border: 2px solid #d32f2f; border-radius: 8px; background-color: #ffebee; margin-bottom: 20px;">
                           <div style="color: #d32f2f; margin-bottom: 15px;">
                               <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#d32f2f" style="margin-bottom: 10px;">
@@ -789,8 +843,8 @@ function submitForm() {
                               </p>
                           </div>
                       </div>`;
-              } else if (content.isLDiversity) {
-                  visualizationHtml += `
+            } else if (content.isLDiversity) {
+              visualizationHtml += `
                       <div class="error-container" style="text-align: center; padding: 20px; border: 2px solid #d32f2f; border-radius: 8px; background-color: #ffebee; margin-bottom: 20px;">
                           <div style="color: #d32f2f; margin-bottom: 15px;">
                               <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#d32f2f" style="margin-bottom: 10px;">
@@ -807,8 +861,8 @@ function submitForm() {
                               </p>
                           </div>
                       </div>`;
-              } else if (content.isTCloseness) {
-                  visualizationHtml += `
+            } else if (content.isTCloseness) {
+              visualizationHtml += `
                       <div class="error-container" style="text-align: center; padding: 20px; border: 2px solid #d32f2f; border-radius: 8px; background-color: #ffebee; margin-bottom: 20px;">
                           <div style="color: #d32f2f; margin-bottom: 15px;">
                               <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#d32f2f" style="margin-bottom: 10px;">
@@ -825,8 +879,8 @@ function submitForm() {
                               </p>
                           </div>
                       </div>`;
-              } else if (content.isClassImbalance) {
-                  visualizationHtml += `
+            } else if (content.isClassImbalance) {
+              visualizationHtml += `
                       <div class="error-container" style="text-align: center; padding: 20px; border: 2px solid #d32f2f; border-radius: 8px; background-color: #ffebee; margin-bottom: 20px;">
                           <div style="color: #d32f2f; margin-bottom: 15px;">
                               <svg xmlns="http://www.w3.org/2000/svg" height="32px" viewBox="0 -960 960 960" width="32px" fill="#d32f2f" style="margin-bottom: 10px;">
@@ -843,19 +897,19 @@ function submitForm() {
                               </p>
                           </div>
                       </div>`;
-              } else {
-                  visualizationHtml += `<div style="text-align: center; padding: 20px; color: #d32f2f;">
+            } else {
+              visualizationHtml += `<div style="text-align: center; padding: 20px; color: #d32f2f;">
                       <strong>Error:</strong> ${content.description}
                   </div>`;
-              }
+            }
           } else if (content.image && content.image.trim() !== "") {
-              // Handle valid visualization image
-              const imageBlobUrl = `data:image/png;base64,${content.image}`;
-              visualizationHtml += `<img src="${imageBlobUrl}" alt="Visualization ${index + 1} Chart">
+            // Handle valid visualization image
+            const imageBlobUrl = `data:image/png;base64,${content.image}`;
+            visualizationHtml += `<img src="${imageBlobUrl}" alt="Visualization ${index + 1} Chart">
                       <a href="${imageBlobUrl}" download="${content.title}.png" class="toggle metric-download" style="padding:0px;"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"><path d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z"/></svg></a>`;
           } else if (!content.isAsync) {
-              // Display message for empty visualization (only for non-async tasks)
-              visualizationHtml += `<div style="text-align: center; padding: 20px; color: #666;">
+            // Display message for empty visualization (only for non-async tasks)
+            visualizationHtml += `<div style="text-align: center; padding: 20px; color: #666;">
                       No visualization available for this metric.
                   </div>`;
           }
@@ -870,7 +924,7 @@ function submitForm() {
           </div>`;
 
           metrics.innerHTML += visualizationHtml;
-      });
+        });
 
         // Check if duplicity is present and 0 (no duplicity)
         if (
@@ -911,7 +965,7 @@ function submitForm() {
         // Assuming 'data' is your dictionary
         const modifiedData = removeVisualizationKey(data);
         const jsonBlobUrl = `data:application/json,${encodeURIComponent(
-          JSON.stringify(modifiedData)
+          JSON.stringify(modifiedData),
         )}`;
         // Add the "Download JSON" link for the last jsonData outside the loop
         metrics.innerHTML += `<a href="${jsonBlobUrl}" download="report.json" class="toggle">Download JSON Report</a>`;
@@ -946,7 +1000,7 @@ function submitForm() {
         // Assuming 'data' is your dictionary
         const modifiedData = removeVisualizationKey(data);
         const jsonBlobUrl = `data:application/json,${encodeURIComponent(
-          JSON.stringify(modifiedData)
+          JSON.stringify(modifiedData),
         )}`;
         // Add the "Download JSON" link for the last jsonData outside the loop
         metrics.innerHTML += `<a href="${jsonBlobUrl}" download="report.json" class="toggle">Download JSON Report</a>`;
@@ -956,7 +1010,8 @@ function submitForm() {
       console.error("Error:", error);
       var metrics = document.getElementById("metrics");
       if (metrics) {
-        metrics.innerHTML = "<p style='color:red;text-align:center;'>An error occurred while loading results. Please try again.</p>";
+        metrics.innerHTML =
+          "<p style='color:red;text-align:center;'>An error occurred while loading results. Please try again.</p>";
       }
       openErrorPopup("Visualization Error", error.message || String(error));
     });
@@ -1016,7 +1071,7 @@ function pollAsyncTask(
   cacheKey,
   metricName,
   maxAttempts = 800,
-  interval = 1500
+  interval = 1500,
 ) {
   let attempts = 0;
 
@@ -1037,7 +1092,7 @@ function pollAsyncTask(
 
         // Get DOM elements for progress bar and status
         const asyncTaskElement = document.querySelector(
-          `[data-task-id="${taskId}"]`
+          `[data-task-id="${taskId}"]`,
         );
         const statusSpan = asyncTaskElement
           ? asyncTaskElement.querySelector(`#task-status-${taskId}`)
@@ -1057,7 +1112,7 @@ function pollAsyncTask(
             "DEBUG: Task failed with status:",
             data.status,
             "error:",
-            data.error || data.result?.error
+            data.error || data.result?.error,
           );
 
           // Update progress bar to show failure
@@ -1191,7 +1246,7 @@ function pollAsyncTask(
             statusSpan.textContent = "Taking longer than expected...";
           }
           console.warn(
-            `${metricName} polling timeout reached. Task may still be running.`
+            `${metricName} polling timeout reached. Task may still be running.`,
           );
         }
       })
@@ -1204,11 +1259,11 @@ function pollAsyncTask(
           debugLog(
             "DEBUG: Max retries reached for",
             metricName,
-            "creating error result"
+            "creating error result",
           );
 
           const asyncTaskElement = document.querySelector(
-            `[data-task-id="${taskId}"]`
+            `[data-task-id="${taskId}"]`,
           );
           const progressBar = asyncTaskElement
             ? asyncTaskElement.querySelector(".progress-bar")
@@ -1229,7 +1284,7 @@ function pollAsyncTask(
           const errorResult = { error: `Connection error: ${error.message}` };
           debugLog(
             "DEBUG: Calling updateAsyncTaskWithResults with connection error for",
-            metricName
+            metricName,
           );
           setTimeout(() => {
             updateAsyncTaskWithResults(taskId, metricName, errorResult);
@@ -1243,10 +1298,10 @@ function pollAsyncTask(
 }
 
 function updateAsyncTaskWithResults(taskId, metricName, results) {
-  debugLog(
-    `DEBUG: updateAsyncTaskWithResults called for ${metricName} with:`,
-    { taskId, results }
-  );
+  debugLog(`DEBUG: updateAsyncTaskWithResults called for ${metricName} with:`, {
+    taskId,
+    results,
+  });
 
   // Find the async task placeholder
   const asyncElement = document.querySelector(`[data-task-id="${taskId}"]`);
@@ -1355,7 +1410,7 @@ function updateAsyncTaskWithResults(taskId, metricName, results) {
     ) {
       debugLog(
         "DEBUG: Detected validation error in results:",
-        results.Description
+        results.Description,
       );
 
       // Extract the actual error message
@@ -1473,7 +1528,7 @@ function updateAsyncTaskWithResults(taskId, metricName, results) {
       if (
         results["Graph interpretation"] &&
         !results["Graph interpretation"].includes(
-          "No visualization available due to error"
+          "No visualization available due to error",
         )
       ) {
         completedHtml += `<div style="color: inherit;"><strong>Graph interpretation:</strong> ${results["Graph interpretation"]}</div>`;
@@ -1511,13 +1566,13 @@ function updateAsyncTaskWithResults(taskId, metricName, results) {
                             <tr>
                                 <td style="color: inherit; background-color: transparent; border-color: inherit;"><strong>${featureName}</strong></td>
                                 <td style="color: inherit; background-color: transparent; border-color: inherit;">${featureStats.mean.toFixed(
-                                  3
+                                  3,
                                 )}</td>
                                 <td style="color: inherit; background-color: transparent; border-color: inherit;">${featureStats.std.toFixed(
-                                  3
+                                  3,
                                 )}</td>
                                 <td style="color: inherit; background-color: transparent; border-color: inherit;">${featureStats.min.toFixed(
-                                  3
+                                  3,
                                 )}</td>
                                 <td style="color: inherit; background-color: transparent; border-color: inherit;">${featureStats[
                                   "25%"
@@ -1529,7 +1584,7 @@ function updateAsyncTaskWithResults(taskId, metricName, results) {
                                   "75%"
                                 ].toFixed(3)}</td>
                                 <td style="color: inherit; background-color: transparent; border-color: inherit;">${featureStats.max.toFixed(
-                                  3
+                                  3,
                                 )}</td>
                             </tr>`;
           }
@@ -1552,13 +1607,13 @@ function updateAsyncTaskWithResults(taskId, metricName, results) {
                                 </tr>
                                 <tr>
                                     <td style="color: inherit; background-color: transparent; border-color: inherit;">${stats.mean.toFixed(
-                                      3
+                                      3,
                                     )}</td>
                                     <td style="color: inherit; background-color: transparent; border-color: inherit;">${stats.std.toFixed(
-                                      3
+                                      3,
                                     )}</td>
                                     <td style="color: inherit; background-color: transparent; border-color: inherit;">${stats.min.toFixed(
-                                      3
+                                      3,
                                     )}</td>
                                     <td style="color: inherit; background-color: transparent; border-color: inherit;">${stats[
                                       "25%"
@@ -1570,7 +1625,7 @@ function updateAsyncTaskWithResults(taskId, metricName, results) {
                                       "75%"
                                     ].toFixed(3)}</td>
                                     <td style="color: inherit; background-color: transparent; border-color: inherit;">${stats.max.toFixed(
-                                      3
+                                      3,
                                     )}</td>
                                 </tr>
                             </table>
@@ -1610,7 +1665,7 @@ function updateAsyncTaskWithResults(taskId, metricName, results) {
 function updateTaskStatus(taskId, metricName, status, message) {
   // Find the async task status element for this metric
   const asyncElements = document.querySelectorAll(
-    `[data-metric-name="${metricName}"]`
+    `[data-metric-name="${metricName}"]`,
   );
 
   if (asyncElements.length > 0) {
@@ -2156,8 +2211,12 @@ function toggleValue(checkbox) {
   // Find all select dropdowns within that container
   const dropdowns = container.querySelectorAll("select");
   const inputs = container.querySelectorAll("input.textWrapper");
-  const checkboxes = container.querySelectorAll("input.checkbox.individual:not(.target-feature)");
-  const selectAllCheckboxs = container.querySelectorAll("input.checkbox.select-all");
+  const checkboxes = container.querySelectorAll(
+    "input.checkbox.individual:not(.target-feature)",
+  );
+  const selectAllCheckboxs = container.querySelectorAll(
+    "input.checkbox.select-all",
+  );
   // Enable or disable all dropdowns inside the container based on checkbox state
 
   dropdowns.forEach((dropdown) => {
@@ -2167,7 +2226,6 @@ function toggleValue(checkbox) {
     input.disabled = !checkbox.checked;
   });
   checkboxes.forEach((input) => {
-
     input.disabled = !checkbox.checked;
   });
   //toggle select all checkboxes state
@@ -2188,7 +2246,7 @@ function toggleValue(checkbox) {
   // If this is the class imbalance checkbox, update cross-disabling
   if (checkbox.name === "class imbalance") {
     debugLog("Class imbalance checkbox toggled, updating cross-disabling");
-    if (typeof updateCrossDisable === 'function') {
+    if (typeof updateCrossDisable === "function") {
       updateCrossDisable();
     }
   }
@@ -2270,7 +2328,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (taskId && cacheKey) {
       debugLog(
-        `Starting polling for ${metricName} from result element: ${taskId}`
+        `Starting polling for ${metricName} from result element: ${taskId}`,
       );
       pollAsyncTask(taskId, cacheKey, metricName);
     }
@@ -2278,7 +2336,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Also check for async task status elements specifically
   const asyncStatusElements = document.querySelectorAll(
-    ".async-task-status[data-task-id]"
+    ".async-task-status[data-task-id]",
   );
   debugLog("Found", asyncStatusElements.length, "async status elements");
 
@@ -2290,7 +2348,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (taskId && cacheKey) {
       debugLog(
-        `Starting polling for ${metricName} from async status element: ${taskId}`
+        `Starting polling for ${metricName} from async status element: ${taskId}`,
       );
       pollAsyncTask(taskId, cacheKey, metricName);
     }
@@ -2328,56 +2386,57 @@ document.addEventListener("DOMContentLoaded", (event) => {
   const radioButtons = document.querySelectorAll('input[name="tableSwitch"]');
   const tableContainers = document.querySelectorAll(".scrollable-container");
   // popping up current log (only if the button element exists — new inspector uses a link instead)
-  if (dataLogButton) dataLogButton.addEventListener("click", () => {
-    datalogPopup = document.getElementById("datalog-popup");
-    const datalogContent = document.getElementById("datalog-content");
+  if (dataLogButton)
+    dataLogButton.addEventListener("click", () => {
+      datalogPopup = document.getElementById("datalog-popup");
+      const datalogContent = document.getElementById("datalog-content");
 
-    //open popup
-    datalogPopup.classList.add("open-popup");
+      //open popup
+      datalogPopup.classList.add("open-popup");
 
-    fetch("/view-logs")
-      .then((response) => response.json())
-      .then((data) => {
-        const tbodyMaster = document.querySelector("#masterLogTable tbody");
-        const tbodyFile = document.querySelector("#fileUploadLogTable");
-        const tbodyMetric = document.querySelector("#metricLogTable");
-        tbodyMaster.innerHTML = "";
+      fetch("/view-logs")
+        .then((response) => response.json())
+        .then((data) => {
+          const tbodyMaster = document.querySelector("#masterLogTable tbody");
+          const tbodyFile = document.querySelector("#fileUploadLogTable");
+          const tbodyMetric = document.querySelector("#metricLogTable");
+          tbodyMaster.innerHTML = "";
 
-        data.forEach((row) => {
-          const tr = document.createElement("tr");
+          data.forEach((row) => {
+            const tr = document.createElement("tr");
 
-          ["timestamp", "logger", "message"].forEach((key) => {
-            const td = document.createElement("td");
-            td.textContent = row[key];
-            tr.appendChild(td);
+            ["timestamp", "logger", "message"].forEach((key) => {
+              const td = document.createElement("td");
+              td.textContent = row[key];
+              tr.appendChild(td);
+            });
+            tbodyMaster.appendChild(tr);
+
+            // row without logger
+            const trNoLogger = document.createElement("tr");
+            ["timestamp", "message"].forEach((key) => {
+              const td = document.createElement("td");
+              td.textContent = row[key];
+              trNoLogger.appendChild(td);
+            });
+
+            if (row.logger === "file_upload") {
+              tbodyFile.appendChild(trNoLogger);
+            } else if (row.logger === "metric") {
+              tbodyMetric.appendChild(trNoLogger);
+            }
           });
-          tbodyMaster.appendChild(tr);
-
-          // row without logger
-          const trNoLogger = document.createElement("tr");
-          ["timestamp", "message"].forEach((key) => {
-            const td = document.createElement("td");
-            td.textContent = row[key];
-            trNoLogger.appendChild(td);
-          });
-
-          if (row.logger === "file_upload") {
-            tbodyFile.appendChild(trNoLogger);
-          } else if (row.logger === "metric") {
-            tbodyMetric.appendChild(trNoLogger);
-          }
+        })
+        .catch((error) => {
+          console.error("Error loading log:", error);
+          openErrorPopup("Error loading log:", error);
         });
-      })
-      .catch((error) => {
-        console.error("Error loading log:", error);
-        openErrorPopup("Error loading log:", error);
-      });
-  });
+    });
   // switching between logs
   radioButtons.forEach((radio) => {
     radio.addEventListener("change", () => {
       tableContainers.forEach((container) =>
-        container.classList.remove("active")
+        container.classList.remove("active"),
       );
       document.getElementById(radio.value).classList.add("active");
     });
@@ -2396,7 +2455,7 @@ function closeErrorPopup() {
 function setupTooltipPositioning() {
   // Find all info icons in privacy metrics
   const infoIcons = document.querySelectorAll(
-    ".checkboxContainerIndividual .info-icon"
+    ".checkboxContainerIndividual .info-icon",
   );
 
   infoIcons.forEach((icon) => {

--- a/web/templates/_components/llm_settings.html
+++ b/web/templates/_components/llm_settings.html
@@ -1,0 +1,75 @@
+<!-- LLM Settings Modal (triggered from topbar) -->
+<div id="llm-settings-modal" class="hidden fixed inset-0 z-[60] flex items-center justify-center bg-black/50" onclick="if(event.target===this)closeLLMSettings()">
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4 p-6">
+    <div class="flex items-center justify-between mb-4">
+      <h3 class="text-lg font-semibold text-gray-900 dark:text-white">AI Explanation Settings</h3>
+      <button onclick="closeLLMSettings()" class="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors" aria-label="Close">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+      </button>
+    </div>
+
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      Connect to any OpenAI-compatible API to generate AI explanations for metric results.
+      Your API key is stored in the server session only.
+    </p>
+
+    <form id="llm-settings-form" onsubmit="event.preventDefault()">
+      <!-- API Base URL -->
+      <div class="mb-3">
+        <label for="llm-api-base" class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">API Base URL</label>
+        <input type="url" id="llm-api-base" placeholder="https://api.openai.com/v1"
+               class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:ring-blue-500 focus:border-blue-500"
+               value="{{ session.get('llm_config', {}).get('api_base', 'https://api.openai.com/v1') }}">
+      </div>
+
+      <!-- API Key -->
+      <div class="mb-3">
+        <label for="llm-api-key" class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">API Key</label>
+        <input type="password" id="llm-api-key" placeholder="sk-..."
+               class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:ring-blue-500 focus:border-blue-500"
+               value="{{ '••••••••' if session.get('llm_config', {}).get('api_key') else '' }}">
+      </div>
+
+      <!-- Model -->
+      <div class="mb-3">
+        <label for="llm-model" class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">Model</label>
+        <input type="text" id="llm-model" placeholder="gpt-4o-mini"
+               class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:ring-blue-500 focus:border-blue-500"
+               value="{{ session.get('llm_config', {}).get('model', 'gpt-4o-mini') }}">
+      </div>
+
+      <!-- Temperature -->
+      <div class="mb-4">
+        <label for="llm-temperature" class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">Temperature</label>
+        <input type="number" id="llm-temperature" min="0" max="2" step="0.1" placeholder="0.5"
+               class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:ring-blue-500 focus:border-blue-500"
+               value="{{ session.get('llm_config', {}).get('temperature', 0.5) }}">
+        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">0 = deterministic, 2 = creative (default 0.5)</p>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex items-center justify-end gap-2">
+        <button type="button" onclick="testLLMConnection()"
+                id="llm-test-btn"
+                class="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-700">
+          Test
+        </button>
+        <button type="button" onclick="saveLLMSettings()"
+                id="llm-save-btn"
+                disabled
+                class="px-4 py-2 text-sm font-medium text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 disabled:opacity-50 disabled:cursor-not-allowed">
+          Save
+        </button>
+        {% if session.get('llm_config', {}).get('api_key') %}
+        <button type="button" onclick="disconnectLLM()"
+                class="px-4 py-2 text-sm font-medium text-red-600 border border-red-300 rounded-lg hover:bg-red-50 dark:text-red-400 dark:border-red-600 dark:hover:bg-red-900/20">
+          Disconnect
+        </button>
+        {% endif %}
+      </div>
+
+      <!-- Status message -->
+      <div id="llm-settings-status" class="mt-3 text-sm hidden"></div>
+    </form>
+  </div>
+</div>

--- a/web/templates/_components/topbar.html
+++ b/web/templates/_components/topbar.html
@@ -49,6 +49,12 @@
           <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"/></svg>
         </a>
         {% endif %}
+        {% if llm_available %}
+        <!-- AI Explanations -->
+        <button onclick="openLLMSettings()" class="p-2 rounded-lg hover:bg-black/10 dark:hover:bg-white/10 transition-colors {% if llm_configured %}text-purple-500{% endif %}" title="AI Explanation Settings" aria-label="AI Explanation Settings">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"/></svg>
+        </button>
+        {% endif %}
         <!-- Logs -->
         <a href="{{ url_for('admin.logs_page') }}" class="p-2 rounded-lg hover:bg-black/10 dark:hover:bg-white/10 transition-colors" title="Application Logs" aria-label="View logs">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"/></svg>

--- a/web/templates/inspector.html
+++ b/web/templates/inspector.html
@@ -19,6 +19,11 @@
   <!-- Top bar -->
   {% include '_components/topbar.html' %}
 
+  <!-- LLM settings modal (only when openai is installed) -->
+  {% if llm_available %}
+    {% include '_components/llm_settings.html' %}
+  {% endif %}
+
   <!-- Sidebar (only visible when file is uploaded) -->
   {% if uploaded_file_path %}
     {% include '_components/sidebar.html' %}
@@ -70,6 +75,10 @@
   <script src="{{ url_for('static', filename='js/inspector.js') }}"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
+      {% if llm_available and llm_configured %}
+        window.AIDRIN_LLM_ENABLED = true;
+      {% endif %}
+
       {% if uploaded_file_path and not globus_mode %}
         initWorkspace();
       {% elif globus_mode %}


### PR DESCRIPTION
# Related Issues / Pull Requests                                                                                                                                                                                       
                                                                                                                                                                                                                         
  - Replaces [#48](https://github.com/idtlab/AIDRIN/pull/48) (Draft: include module to explain results with AI)                                                                                                          
                                                            
  # Description                                                                                                                                                                                                          
                                                            
  Adds optional LLM-powered explanations of metric results using any OpenAI-compatible API. This is a full reimplementation of the approach in #48, addressing the issues in that draft (hardcoded env vars, blocking    
  calls, string interpolation bug, missing error handling) with a session-based configuration, non-blocking async rendering, vision fallback, and server-side caching of explanations.
                                                                                                                                                                                                                         
  Install with `pip install aidrin[llm]`. When the `openai` package is not installed, the feature is completely hidden with zero overhead.                                                                               
  
  # What changes are proposed in this pull request?                                                                                                                                                                      
                                                            
  - [ ] Bug fix (non-breaking change which fixes an issue)                                                                                                                                                               
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
  - [x] This change requires a documentation update                                                                                                                                                                      
  
  ### New files                                                                                                                                                                                                          
  - `web/llm.py` — Optional dependency detection, `explain_metric()` with vision fallback to text-only
  - `web/routes/llm.py` — Flask routes: `/llm/configure`, `/llm/test`, `/llm/explain`, `/llm/cache-explanation`, `/llm/status`, `/llm/disconnect`                                                                        
  - `web/templates/_components/llm_settings.html` — Settings modal (API URL, key, model, temperature)                                                                                                                    
  - `tests/integration/test_llm.py` — 7 tests covering availability, config, explain, disconnect                                                                                                                         
                                                                                                                                                                                                                         
  ### Modified files                                                                                                                                                                                                     
  - `pyproject.toml` — Added `llm = ["openai>=1.0"]` optional extra                                                                                                                                                      
  - `web/routes/__init__.py` — Conditional blueprint registration for `llm_bp`                                                                                                                                           
  - `web/routes/core.py` — Passes `llm_available`/`llm_configured` to template; new `/cached-result/<metric>` endpoint returns cached LLM explanations                                                                   
  - `web/routes/utils.py` — `store_result()` saves persistent user-scoped cache copy for result + explanation restore                                                                                                    
  - `web/templates/inspector.html` — Includes LLM settings modal, sets `window.AIDRIN_LLM_ENABLED` flag                                                                                                                  
  - `web/templates/_components/topbar.html` — Sparkle icon (turns purple when configured)                                                                                                                                
  - `web/static/js/inspector.js` — `requestLLMExplanation()`, `_restoreCachedResult()` with LLM cache restore, form state save/restore via `sessionStorage`, temperature in config                                       
  - `web/static/js/main.js` — `clearFile()` clears saved form states                                                                                                                                                     
  - `docs/source/contributing.rst` — New "LLM Explanations" section with setup, architecture, Ollama quickstart                                                                                                          
  - `docs/source/usage.rst` — Added AI explanation step to web workflow                                                                                                                                                  
  - `docs/source/installation.rst` — Added optional extras block
                                                                                                                                                                                                                         
  ### Key improvements over #48                             
                                                                                                                                                                                                                         
  | Issue in #48 | This PR |                                                                                                                                                                                             
  |---|---|
  | Environment variables only (shared, requires restart) | Per-user session config via UI modal |                                                                                                                       
  | `{description}` string interpolation bug | Proper prompt construction, description in user message |                                                                                                                 
  | `print()` instead of logging | `logging.getLogger(__name__)` throughout |                                                                                                                                            
  | Blocking (metric waits for LLM) | Non-blocking (explanation loads after results render) |                                                                                                                            
  | Hardcoded to one provider | Any OpenAI-compatible API (OpenAI, Ollama, vLLM, Azure) |                                                                                                                                
  | `openai` always required | Optional extra: `pip install aidrin[llm]` |                                                                                                                                               
  | No error feedback | Yellow warning callout with actual error message |                                                                                                                                               
  | No caching | Explanations cached server-side, restored on panel revisit |                                                                                                                                            
  | No connection validation | Test → Save workflow validates credentials first |                                                                                                                                        
  | Fixed temperature | Configurable temperature (default 0.5) |                                                                                                                                                         
  | No model attribution | Model name shown in each explanation callout |                                                                                                                                                
  | No vision fallback | Auto-retries text-only if model doesn't support images |                                                                                                                                        
                                                                                                                                                                                                                         
  # Checklist:                                                                                                                                                                                                           
                                                                                                                                                                                                                         
  - [x] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
  - [x] I have commented my code
  - [x] My code requires documentation updates, and I have made corresponding changes to the documentation                                                                                                               
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes              