### PR TITLE
Fix CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Python Lint

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   prettier:
     name: Prettier

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/tests/integration/test_inspector.py
+++ b/tests/integration/test_inspector.py
@@ -64,7 +64,7 @@ def test_inspector_get_no_file(client):
     html = response.data.decode()
     assert "AI Data Readiness Inspector" in html
     assert "Select a File Type" in html
-    assert "aidrin.readthedocs.io" in html
+    assert "https://aidrin.readthedocs.io/en/latest/" in html
 
 
 def test_inspector_contains_version(uploaded_client):

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -14,6 +14,7 @@ from flask import (
     session,
     url_for,
 )
+from werkzeug.utils import secure_filename
 from aidrin.file_handling.file_parser import SUPPORTED_FILE_TYPES, READER_MAP, read_file
 from web.routes.utils import (
     clear_all_user_cache,
@@ -46,7 +47,7 @@ def inspector():
             )
 
             display_name = file.filename
-            filename = f"{uuid.uuid4().hex}_{file.filename}"
+            filename = f"{uuid.uuid4().hex}_{secure_filename(file.filename)}"
             file_path = os.path.join(current_app.config["UPLOAD_FOLDER"], filename)
             file.save(file_path)
 
@@ -145,7 +146,7 @@ def inspector():
         )
     except Exception as e:
         file_upload_time_log.error("Error rendering workspace: %s", e, exc_info=True)
-        return f"<h1>Workspace render error</h1><pre>{e}</pre>", 500
+        return "<h1>Workspace render error</h1>", 500
 
 
 @core_bp.route("/upload-file", methods=["GET", "POST"])
@@ -199,9 +200,9 @@ def clear_file():
             file_path = os.path.join(upload_folder, filename)
             if os.path.isfile(file_path):
                 os.remove(file_path)
-    except Exception as e:
-        file_upload_time_log.info("File Clear Failure: Unable to clear folder")
-        return jsonify({"success": False, "error": str(e)}), 500
+    except Exception:
+        file_upload_time_log.error("File Clear Failure: Unable to clear folder", exc_info=True)
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
     return redirect(url_for("core.inspector"))
 
@@ -227,8 +228,8 @@ def filter_file():
 
         return jsonify({"success": True, "message": "File filtered successfully"})
     except Exception as e:
-        file_upload_time_log.error("Error in filter_file: %s", e)
-        return jsonify({"success": False, "error": str(e)}), 500
+        file_upload_time_log.error("Error in filter_file: %s", e, exc_info=True)
+        return jsonify({"success": False, "error": "An internal error occurred"}), 500
 
 
 @core_bp.route("/my-cache", methods=["GET"])
@@ -274,7 +275,8 @@ def clear_cache():
             }
         )
     except Exception as e:
-        return jsonify({"success": False, "message": f"Error clearing cache: {str(e)}"}), 500
+        file_upload_time_log.error("Error clearing cache: %s", e, exc_info=True)
+        return jsonify({"success": False, "message": "An internal error occurred"}), 500
 
 
 @core_bp.route("/cached-result/<metric_name>")
@@ -308,7 +310,8 @@ def summary_statistics():
                 return redirect(url_for("core.summary_statistics"))
             return redirect(url_for("core.inspector"))
         except Exception as e:
-            return jsonify({"success": False, "message": str(e)})
+            file_upload_time_log.error("Error in summary_statistics POST: %s", e, exc_info=True)
+            return jsonify({"success": False, "message": "An internal error occurred"})
 
     try:
         file_path = session.get("uploaded_file_path")
@@ -356,7 +359,8 @@ def summary_statistics():
         })
         return jsonify(response_data)
     except Exception as e:
-        return jsonify({"success": False, "message": str(e)})
+        file_upload_time_log.error("Error computing summary statistics: %s", e, exc_info=True)
+        return jsonify({"success": False, "message": f"{type(e).__name__}: {e}"})
 
 
 @core_bp.route("/feature-set", methods=["POST"])
@@ -398,4 +402,5 @@ def extract_features():
         }
         return jsonify(response_data)
     except Exception as e:
-        return jsonify({"success": False, "message": str(e)})
+        file_upload_time_log.error("Error extracting features: %s", e, exc_info=True)
+        return jsonify({"success": False, "message": f"{type(e).__name__}: {e}"})

--- a/web/routes/custom.py
+++ b/web/routes/custom.py
@@ -145,8 +145,8 @@ def custom_metrics():
             final_dict = ensure_json_serializable(final_dict)
 
         except Exception as e:
-            metric_time_log.error("Custom Metric error: %s", e)
-            return jsonify({"error": str(e)}), 500
+            metric_time_log.error("Custom Metric error: %s", e, exc_info=True)
+            return jsonify({"error": f"{type(e).__name__}: {e}"}), 500
 
         finally:
             if module_name and module_name in sys.modules:

--- a/web/routes/globus.py
+++ b/web/routes/globus.py
@@ -73,7 +73,8 @@ def auth():
         }
         return redirect(auth_url)
     except ValueError as e:
-        return jsonify({"error": str(e)}), 500
+        logger.error("Globus auth URL error: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error occurred"}), 500
 
 
 @globus_bp.route("/callback")
@@ -104,8 +105,8 @@ def callback():
         return redirect(url_for("core.inspector"))
 
     except Exception as e:
-        logger.error("Globus Auth callback error: %s", e)
-        return jsonify({"error": f"Authentication failed: {str(e)}"}), 500
+        logger.error("Globus Auth callback error: %s", e, exc_info=True)
+        return jsonify({"error": "Authentication failed"}), 500
 
 
 # ---------------------------------------------------------------------------
@@ -219,8 +220,8 @@ def submit():
         })
 
     except Exception as e:
-        logger.error("Globus submit error: %s", e)
-        return jsonify({"error": f"Failed to submit task: {str(e)}"}), 500
+        logger.error("Globus submit error: %s", e, exc_info=True)
+        return jsonify({"error": "Failed to submit task"}), 500
 
 
 @globus_bp.route("/cache-summary", methods=["POST"])
@@ -269,5 +270,5 @@ def check_task_status(task_id):
         return jsonify(result)
 
     except Exception as e:
-        logger.error("Globus check-task error: %s", e)
-        return jsonify({"status": "failed", "error": str(e)}), 500
+        logger.error("Globus check-task error: %s", e, exc_info=True)
+        return jsonify({"status": "failed", "error": "An internal error occurred"}), 500

--- a/web/routes/llm.py
+++ b/web/routes/llm.py
@@ -58,16 +58,17 @@ def configure():
     except (TypeError, ValueError):
         temperature = 0.5
 
+    api_base = (data.get("api_base") or "https://api.openai.com/v1").strip()
+    model = (data.get("model") or "gpt-4o-mini").strip()
+
     session["llm_config"] = {
-        "api_base": (data.get("api_base") or "https://api.openai.com/v1").strip(),
+        "api_base": api_base,
         "api_key": api_key,
-        "model": (data.get("model") or "gpt-4o-mini").strip(),
+        "model": model,
         "temperature": max(0.0, min(2.0, temperature)),
     }
 
-    logger.info("LLM configured: model=%s, base=%s",
-                session["llm_config"]["model"],
-                session["llm_config"]["api_base"])
+    logger.info("LLM configured: model=%s, base=%s", model, api_base)
     return jsonify({"success": True})
 
 
@@ -118,7 +119,7 @@ def test_connection():
         return jsonify({"success": True, "reply": reply})
     except Exception as e:
         logger.warning("LLM test connection failed: %s", e)
-        return jsonify({"error": str(e)}), 400
+        return jsonify({"error": f"{type(e).__name__}: {e}"}), 400
 
 
 # ---------------------------------------------------------------------------
@@ -171,8 +172,8 @@ def explain():
     try:
         explanation = explain_metric(full_description, visualization, config)
     except Exception as e:
-        logger.error("LLM explain error: %s", e)
-        return jsonify({"error": str(e)}), 500
+        logger.error("LLM explain error: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error occurred"}), 500
 
     if not explanation:
         return jsonify({"error": "LLM returned an empty response"}), 500

--- a/web/routes/metrics.py
+++ b/web/routes/metrics.py
@@ -126,8 +126,8 @@ def data_quality():
                     metric_time_log.info("Duplicity took %.2f seconds", time.time() - t0)
 
             except Exception as e:
-                metric_time_log.error("Data Quality error: %s", e)
-                return jsonify({"error": str(e)}), 200
+                metric_time_log.error("Data Quality error: %s", e, exc_info=True)
+                return jsonify({"error": f"{type(e).__name__}: {e}"}), 200
 
             duration_ms = (time.time() - start_time) * 1000
             span.set_attribute("metric.duration_ms", duration_ms)
@@ -300,8 +300,8 @@ def correlation_analysis():
             else:
                 return jsonify({"message": "No correlation analysis selected"}), 200
         except Exception as e:
-            metric_time_log.error("Correlation Analysis error: %s", e)
-            return jsonify({"error": str(e)}), 200
+            metric_time_log.error("Correlation Analysis error: %s", e, exc_info=True)
+            return jsonify({"error": f"{type(e).__name__}: {e}"}), 200
 
     return get_result_or_default("metrics.correlation_analysis", file_path, file_name)
 
@@ -359,8 +359,8 @@ def feature_relevance():
                 if df_json is None:
                     return jsonify({"trigger": "correlationError", "error": "Data cleaning failed"}), 200
             except Exception as e:
-                metric_time_log.error("Feature Relevance — data cleaning error: %s", e)
-                return jsonify({"trigger": "correlationError", "error": str(e)}), 200
+                metric_time_log.error("Feature Relevance — data cleaning error: %s", e, exc_info=True)
+                return jsonify({"trigger": "correlationError", "error": f"{type(e).__name__}: {e}"}), 200
 
             try:
                 t0 = time.time()
@@ -375,8 +375,8 @@ def feature_relevance():
                         {"trigger": "correlationError", "error": "No valid correlations could be calculated"}
                     ), 200
             except Exception as e:
-                metric_time_log.error("Feature Relevance — Pearson correlation error: %s", e)
-                return jsonify({"trigger": "correlationError", "error": str(e)}), 200
+                metric_time_log.error("Feature Relevance — Pearson correlation error: %s", e, exc_info=True)
+                return jsonify({"trigger": "correlationError", "error": f"{type(e).__name__}: {e}"}), 200
 
             try:
                 t0 = time.time()
@@ -739,8 +739,8 @@ def hipaa_compliance():
             final_dict = ensure_json_serializable(final_dict)
 
         except Exception as e:
-            metric_time_log.error("HIPAA Compliance error: %s", e)
-            return jsonify({"error": str(e)}), 500
+            metric_time_log.error("HIPAA Compliance error: %s", e, exc_info=True)
+            return jsonify({"error": f"{type(e).__name__}: {e}"}), 500
 
         duration = time.time() - start_time
         metric_time_log.info("HIPAA Compliance Evaluation completed in %.2f seconds", duration)
@@ -808,7 +808,8 @@ def fair_assessment():
             return redirect(url_for("core.inspector"))
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 400
+        metric_time_log.error("FAIR Assessment error: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error occurred"}), 400
 
 
 # ---------------------------------------------------------------------------
@@ -847,7 +848,8 @@ def check_task_status(task_id, metric_name):
                 }
             )
     except Exception as e:
-        return jsonify({"status": "error", "error": str(e)}), 500
+        metric_time_log.error("Task status check error: %s", e, exc_info=True)
+        return jsonify({"status": "error", "error": "An internal error occurred"}), 500
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/js/inspector.js
+++ b/web/static/js/inspector.js
@@ -1650,7 +1650,12 @@ function formatValue(v) {
   return String(v);
 }
 function escapeHtml(str) {
-  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 // ==================== FAIR Assessment ====================

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -1657,8 +1657,9 @@ function updateAsyncTaskWithResults(taskId, metricName, results) {
     asyncElement.style.padding = "0";
     asyncElement.style.textAlign = "left";
 
-    // Replace the content
-    asyncElement.innerHTML = completedHtml;
+    // Replace the content (sanitized — completedHtml interpolates server result
+    // fields that may derive from user-uploaded data)
+    asyncElement.innerHTML = DOMPurify.sanitize(completedHtml);
   }
 }
 

--- a/web/templates/_panels/_custom_metrics.html
+++ b/web/templates/_panels/_custom_metrics.html
@@ -35,7 +35,15 @@
 </div>
 
 <!-- CodeMirror (loaded lazily when panel shown) -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.css"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/theme/eclipse.min.css"/>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/mode/python/python.min.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.css"
+      integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ=="
+      crossorigin="anonymous"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/theme/eclipse.min.css"
+      integrity="sha512-Gv0sGKOVrQcQjUHL+xd9Bpq5AvLKbcQMb8s4J1//caCLxqvj00CLJMzJlqnTHTCQbKFRpPHqzXteq6dSMs7PEw=="
+      crossorigin="anonymous"/>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/codemirror.min.js"
+        integrity="sha512-Kpi2Sp2KpXM2S7aM0p+CwWhm8NuogI15GFPXCmgqAnFr5c86VBXuLEZu0IGBwGSdhhTW6148hP9KTcRMmrjuFQ=="
+        crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.9/mode/python/python.min.js"
+        integrity="sha512-RT0AjIFvx/vuD2Ih9pmIOhlU+HNTpTHGMJ7TORv4oTT0yHqbz9BicxiBohrq84kjvpHnXtWg/wjG0kisHh4EOA=="
+        crossorigin="anonymous"></script>

--- a/web/templates/inspector.html
+++ b/web/templates/inspector.html
@@ -3,8 +3,13 @@
 {% block title %}AIDRIN - Inspector{% endblock %}
 
 {% block head_extra %}
-  <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.6.4.min.js"
+          integrity="sha512-pumBsjNRGGqkPzKHndZMaAG+bir374sORyzM3uulLV14lN5LyykqNk8eEeUlUkB3U0M4FApyaHraT65ihJhDpQ=="
+          crossorigin="anonymous"></script>
   <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.7/purify.min.js"
+          integrity="sha512-78KH17QLT5e55GJqP76vutp1D2iAoy06WcYBXB6iBCsmO6wWzx0Qdg8EDpm8mKXv68BcvHOyeeP4wxAL0twJGQ=="
+          crossorigin="anonymous"></script>
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
   <script>
     var retrieveFileUrl = "{{ url_for('core.retrieve_uploaded_file') }}";


### PR DESCRIPTION
## Summary

Remediates the code-scanning alerts reported by GitHub CodeQL after enabling code scanning on the repo. 15 files changed; covers all 39 alerts.

## Changes

**Workflow hardening** — added `permissions: contents: read` to all 5 workflows (`missing-workflow-permissions`).

**Frontend**
- Added Subresource Integrity (`integrity` + `crossorigin`) to the jQuery and CodeMirror CDN assets.
- Added DOMPurify and sanitize async-result HTML before `innerHTML` assignment (`xss-through-dom`).
- `escapeHtml` now also escapes `"` and `'` (`incomplete-html-attribute-sanitization`).

**Backend**
- Uploaded filenames now pass through `werkzeug.secure_filename` (`path-injection`).
- LLM config logging reads `model`/`api_base` from locals instead of the dict that holds the API key (`clear-text-logging-sensitive-data`).
- Exception text removed from HTTP responses (`stack-trace-exposure`): server (500) errors return a generic message and are logged with `exc_info=True`; metric/validation errors keep a short `Type: message` form so users still get diagnostics.

**Tests** — tightened a `readthedocs.io` substring assertion to a full URL.

## Verification
- `flake8 --config=tox.ini`: clean
- `pytest tests/unit tests/integration`: **300 passed**
- `prettier --check web/static/js web/static/css`: clean
- `node --check` on edited JS: OK
- Browser: SRI check passed — no blocked resources, jQuery 3.6.4 + DOMPurify load, page renders normally.

## Reviewer note — alerts that stay open by design

~12 metric/validation error returns intentionally keep diagnostic detail (`f"{type(e).__name__}: {e}"`) so users still see why a metric failed. CodeQL will keep flagging these; **dismiss them in the Security tab as accepted risk**:

- `metrics.py` 130/304/363/379/391/743/784/789
- `custom.py` 149
- `core.py` 359/401
- `llm.py` 121
- `globus.py` 269 (surfaces the remote Globus task result — left as-is)

The ~15 server-error (500) returns and all non-stack-trace alerts should clear on the next scan.

## Out of scope (follow-up)

`web/templates/_base.html` loads the Tailwind Play CDN (`cdn.tailwindcss.com`), which is not production-supported. Pre-existing; tracked separately for its own PR.