### PR TITLE
docs: add Windows Celery worker instructions with --pool=solo

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -111,10 +111,30 @@ Terminal 1 – Redis Server
 Terminal 2 – Celery Worker
 """"""""""""""""""""""""""
 
+**macOS / Linux:**
+
 .. code-block:: bash
 
    conda activate aidrin-env
    PYTHONPATH=. celery -A worker.make_celery worker --beat --loglevel=info
+
+**Windows:**
+
+If you see errors such as:
+
+- ``-B option does not work on Windows. Please run celery beat as a separate service.``
+- ``Can't pickle local object 'celery_init_app.<locals>.FlaskTask'``
+
+Use the ``solo`` pool instead (no ``--beat`` required for local development):
+
+.. code-block:: powershell
+
+   conda activate aidrin-env
+   $env:PYTHONPATH = "."
+   celery -A worker.make_celery worker --loglevel=info --pool=solo
+
+If you use a venv rather than Conda, activate it first and set ``PYTHONPATH`` the
+same way before running the ``celery`` command.
 
 Terminal 3 – Flask Server
 """""""""""""""""""""""""

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -144,6 +144,23 @@ Terminal 3 – Flask Server
    conda activate aidrin-env
    flask --app 'web:create_app()' run --debug
 
+.. note::
+
+   **Windows:** If you see ``-B option does not work on Windows`` or
+   ``Can't pickle local object 'celery_init_app.<locals>.FlaskTask'``, drop
+   ``--beat`` from the worker command and use ``--pool=solo`` instead:
+
+   .. code-block:: powershell
+
+      PYTHONPATH=. celery -A worker.make_celery worker --pool=solo --loglevel=info
+
+   To run periodic tasks, start Beat in a **separate** terminal (optional for
+   local development):
+
+   .. code-block:: powershell
+
+      PYTHONPATH=. celery -A worker.make_celery beat --loglevel=info
+
 Once running, visit:
 `http://127.0.0.1:5000 <http://127.0.0.1:5000>`_
 


### PR DESCRIPTION
# Description

Adds Windows-specific instructions for starting the Celery worker during local development. On Windows, the documented default command (worker --beat with the prefork pool) can fail with --beat unsupported and a FlaskTask pickle error. This PR documents the --pool=solo workaround and the correct PYTHONPATH setup for PowerShell.

# What changes are proposed in this pull request?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [x] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [x] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
