### PR TITLE
enforce configurable upload size limit at the web layer

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -127,6 +127,13 @@ Terminal 3 – Flask Server
 Once running, visit:
 `http://127.0.0.1:5000 <http://127.0.0.1:5000>`_
 
+.. note::
+
+   The maximum upload size defaults to **1 GB**. To change it for a deployment,
+   set the ``AIDRIN_MAX_UPLOAD_MB`` environment variable (in megabytes) before
+   starting the Flask server, e.g.
+   ``AIDRIN_MAX_UPLOAD_MB=2048 flask --app 'web:create_app()' run``.
+
 ----
 
 Option 2: Install from PyPI

--- a/docs/source/limitations.rst
+++ b/docs/source/limitations.rst
@@ -38,8 +38,14 @@ What We Cannot Do
 File and Size Limits
 --------------------
 
-- Maximum supported file size: **100 MB per file** (web interface may vary depending on server resources).
-- If a file exceeds the limits, the system will time out.
+- Maximum upload size: **1 GB per file** by default. Uploads larger than the limit
+  are rejected immediately with an HTTP ``413`` response before the file is saved,
+  so no partial data is stored.
+- The limit is configurable per deployment via the ``AIDRIN_MAX_UPLOAD_MB``
+  environment variable (value in megabytes). For example, ``AIDRIN_MAX_UPLOAD_MB=2048``
+  raises the cap to 2 GB.
+- Even within the upload cap, very large datasets may exceed the Celery task time
+  limits or available server memory during analysis.
 
 Data Privacy and Storage
 ------------------------

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -62,6 +62,42 @@ def create_app():
     }
     app.config.from_prefixed_env()
 
+    # Maximum upload size (default 1 GB; override per deployment via AIDRIN_MAX_UPLOAD_MB).
+    # Set after from_prefixed_env so AIDRIN_MAX_UPLOAD_MB takes precedence. Flask rejects
+    # larger request bodies with 413 before the file is ever saved.
+    try:
+        max_upload_mb = int(os.environ.get("AIDRIN_MAX_UPLOAD_MB", 1024))
+    except ValueError:
+        max_upload_mb = 1024
+    app.config["MAX_CONTENT_LENGTH"] = max_upload_mb * 1024 * 1024
+
+    @app.context_processor
+    def inject_upload_limit():
+        # expose the upload limit to templates for client-side validation
+        return dict(
+            max_upload_mb=max_upload_mb,
+            max_upload_bytes=app.config["MAX_CONTENT_LENGTH"],
+        )
+
+    @app.errorhandler(413)
+    def file_too_large(error):
+        from flask import jsonify, request, url_for
+        max_mb = app.config.get("MAX_CONTENT_LENGTH", 0) // (1024 * 1024)
+        message = f"File too large. The maximum upload size is {max_mb} MB."
+        logging.getLogger("file_upload").warning(
+            "Upload rejected: file exceeds %d MB limit", max_mb
+        )
+        if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
+            return jsonify({"error": message}), 413
+        return (
+            f"<!DOCTYPE html><html><head><meta charset='utf-8'><title>File too large</title></head>"
+            f"<body style='font-family:sans-serif;text-align:center;padding:3em;'>"
+            f"<h2>File too large</h2><p>{message}</p>"
+            f"<p><a href='{url_for('core.inspector')}'>Go back to upload</a></p>"
+            f"</body></html>",
+            413,
+        )
+
     # Initialize in-memory cache
     app.TEMP_RESULTS_CACHE = {}
 

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -41,6 +41,20 @@ function uploadForm() {
     return;
   }
 
+  // Check the file does not exceed the server's upload size limit
+  const maxBytes = parseInt(form.dataset.maxUploadBytes, 10);
+  if (maxBytes && fileInput.files[0].size > maxBytes) {
+    const maxMb =
+      form.dataset.maxUploadMb || Math.round(maxBytes / (1024 * 1024));
+    if (typeof showToast === "function")
+      showToast(
+        `File too large. The maximum upload size is ${maxMb} MB.`,
+        "error",
+      );
+    fileInput.value = "";
+    return;
+  }
+
   // Submit the form normally
   form.submit();
 }

--- a/web/templates/_components/upload_panel.html
+++ b/web/templates/_components/upload_panel.html
@@ -31,7 +31,7 @@
     <!-- Local upload card -->
     <div id="local-upload" class="{{ 'hidden' if globus_available and globus_authenticated else '' }}">
       <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-5">
-        <form id="uploadForm" method="post" enctype="multipart/form-data" action="{{ url_for('core.inspector') }}">
+        <form id="uploadForm" method="post" enctype="multipart/form-data" action="{{ url_for('core.inspector') }}" data-max-upload-bytes="{{ max_upload_bytes }}" data-max-upload-mb="{{ max_upload_mb }}">
 
           <!-- File type selector -->
           <label for="fileTypeSelector" class="block text-sm font-medium mb-1.5 text-gray-900 dark:text-white">File type</label>


### PR DESCRIPTION
# Related Issues / Pull Requests

N/A

# Description

The web app accepted arbitrarily large uploads, which were saved and only rejected later when read_file returned an error string, crashing routes that assumed a DataFrame (AttributeError: 'str' object has no attribute 'describe').

Enforce the limit at the HTTP boundary instead: web/__init__.py sets `MAX_CONTENT_LENGTH` from `AIDRIN_MAX_UPLOAD_MB` (default 1 GB), so oversized uploads get a clean 413 before being saved. Adds a 413 handler (friendly HTML for browsers, JSON for XHR) and a client-side size check in the upload form.

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
