### PR TITLE
rebrand: rename inspector to infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AIDRIN – AI Data Readiness Inspector
+# AIDRIN – AI Data Readiness Infrastructure
 
-**AIDRIN** (AI Data Readiness Inspector) is a lightweight, open-source tool designed to evaluate the readiness of datasets for AI and machine learning workflows. It provides an intuitive web interface to assess dataset quality, completeness, and structure through quantitative metrics.
+**AIDRIN** (AI Data Readiness Infrastructure) is a lightweight, open-source tool designed to evaluate the readiness of datasets for AI and machine learning workflows. It provides an intuitive web interface to assess dataset quality, completeness, and structure through quantitative metrics.
 
 For installation, usage, and contribution guidelines, please refer to the [AIDRIN documentation](https://aidrin.readthedocs.io/en/latest/).
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -165,7 +165,7 @@ On the remote machine where your data is located:
    # Start the endpoint
    globus-compute-endpoint start aidrin-endpoint
 
-   # Get the endpoint UUID (copy this for the inspector)
+   # Get the endpoint UUID (copy this for the infrastructure)
    globus-compute-endpoint list
 
 For local testing, you can run an endpoint on the same machine:
@@ -182,11 +182,11 @@ Stop an endpoint with ``globus-compute-endpoint stop <name>``.
 
 - ``aidrin`` must be installed (``pip install aidrin``)
 - Network access to authenticate with Globus
-- The file path entered in the inspector must be accessible from the endpoint machine
+- The file path entered in the infrastructure must be accessible from the endpoint machine
 
 **Usage:**
 
-1. In the inspector, select the "Remote (Globus)" tab
+1. In the infrastructure, select the "Remote (Globus)" tab
 2. Click "Sign in with Globus" (redirects to Globus Auth)
 3. Paste the Globus Compute endpoint UUID
 4. Enter the file path as it exists on the remote machine (e.g., ``/home/user/data/adult.csv``)
@@ -263,7 +263,7 @@ the explanation callout for transparency.
 Debugging the Web Interface
 ============================
 
-AIDRIN's inspector UI includes debug logging that is disabled by default to keep the browser console clean. To enable verbose logging during development:
+AIDRIN's infrastructure UI includes debug logging that is disabled by default to keep the browser console clean. To enable verbose logging during development:
 
 1. Open the browser's developer console (F12 → Console).
 2. Run:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 AIDRIN Documentation
 ====================
 
-**AIDRIN** (AI Data Readiness Inspector) is an open-source tool designed to streamline the preparation and evaluation of datasets for artificial intelligence and machine learning workflows. AIDRIN enables researchers, data scientists, and developers to assess the quality, structure, and readiness of datasets through an intuitive, browser-based interface.
+**AIDRIN** (AI Data Readiness Infrastructure) is an open-source tool designed to streamline the preparation and evaluation of datasets for artificial intelligence and machine learning workflows. AIDRIN enables researchers, data scientists, and developers to assess the quality, structure, and readiness of datasets through an intuitive, browser-based interface.
 
 AIDRIN provides actionable, quantitative metrics to help evaluate datasets across multiple dimensions critical to AI and data science, including:
 

--- a/tests/integration/test_inspector.py
+++ b/tests/integration/test_inspector.py
@@ -62,7 +62,7 @@ def test_inspector_get_no_file(client):
     response = client.get("/inspector")
     assert response.status_code == 200
     html = response.data.decode()
-    assert "AI Data Readiness Inspector" in html
+    assert "AI Data Readiness Infrastructure" in html
     assert "Select a File Type" in html
     assert "https://aidrin.readthedocs.io/en/latest/" in html
 

--- a/tests/integration/test_inspector_upload.py
+++ b/tests/integration/test_inspector_upload.py
@@ -81,7 +81,7 @@ def test_clear_shows_upload_panel(uploaded_client):
     uploaded_client.post("/clear", follow_redirects=True)
     response = uploaded_client.get("/inspector")
     html = response.data.decode()
-    assert "AI Data Readiness Inspector" in html
+    assert "AI Data Readiness Infrastructure" in html
     assert 'id="sidebar"' not in html
 
 
@@ -102,4 +102,4 @@ def test_stale_session_cleared(uploaded_client, app):
     response = uploaded_client.get("/inspector")
     html = response.data.decode()
     assert 'id="sidebar"' not in html
-    assert "AI Data Readiness Inspector" in html
+    assert "AI Data Readiness Infrastructure" in html

--- a/tests/integration/test_pages.py
+++ b/tests/integration/test_pages.py
@@ -87,7 +87,7 @@ def test_publications_has_return_link(client):
     """Publications page should have a link back to inspector."""
     response = client.get("/publications")
     html = response.data.decode()
-    assert "Return to Inspector" in html
+    assert "Return to Infrastructure" in html
 
 
 # -------------------------------------------------

--- a/web/templates/_components/topbar.html
+++ b/web/templates/_components/topbar.html
@@ -14,7 +14,7 @@
         <!-- Title -->
         <a href="/" class="flex items-baseline gap-2">
           <span class="text-lg font-semibold whitespace-nowrap" style="color: var(--textColor); font-family: 'Roboto Slab', Georgia, serif;">AIDRIN</span>
-          <span class="hidden sm:inline text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">AI Data Readiness Inspector</span>
+          <span class="hidden sm:inline text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">AI Data Readiness Infrastructure</span>
         </a>
       </div>
 

--- a/web/templates/_components/upload_panel.html
+++ b/web/templates/_components/upload_panel.html
@@ -6,7 +6,7 @@
     <div class="flex flex-col items-center mb-6">
       <img src="/images/logoNoBackground.png" class="h-20 mb-4" alt="AIDRIN Logo" />
       <h2 class="text-2xl font-semibold text-center text-gray-900 dark:text-white">
-        AI Data Readiness Inspector
+        AI Data Readiness Infrastructure
       </h2>
       <a href="https://aidrin.readthedocs.io/en/latest/" target="_blank"
          class="text-sm mt-2 text-blue-600 dark:text-blue-400 hover:underline">

--- a/web/templates/inspector.html
+++ b/web/templates/inspector.html
@@ -1,6 +1,6 @@
 {% extends '_base.html' %}
 
-{% block title %}AIDRIN - Inspector{% endblock %}
+{% block title %}AIDRIN - Infrastructure{% endblock %}
 
 {% block head_extra %}
   <script src="https://code.jquery.com/jquery-3.6.4.min.js"

--- a/web/templates/logs.html
+++ b/web/templates/logs.html
@@ -7,7 +7,7 @@
 
     <a href="/" class="inline-flex items-center gap-1 text-sm mb-6 text-blue-600 dark:text-blue-400 hover:underline">
       <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="currentColor"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>
-      Back to Inspector
+      Back to Infrastructure
     </a>
 
     <h1 class="text-3xl font-semibold text-gray-900 dark:text-white mb-6">Application Logs</h1>

--- a/web/templates/my_cache.html
+++ b/web/templates/my_cache.html
@@ -11,7 +11,7 @@
 
     <a href="/" class="inline-flex items-center gap-1 text-sm mb-6 text-blue-600 dark:text-blue-400 hover:underline">
       <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="currentColor"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>
-      Back to Inspector
+      Back to Infrastructure
     </a>
 
     <h1 class="text-3xl font-semibold text-gray-900 dark:text-white mb-6">Cache Information</h1>

--- a/web/templates/publications.html
+++ b/web/templates/publications.html
@@ -7,7 +7,7 @@
 
     <a href="/" class="inline-flex items-center gap-1 text-sm mb-6 text-blue-600 dark:text-blue-400 hover:underline">
       <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="currentColor"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>
-      Back to Inspector
+      Back to Infrastructure
     </a>
 
     <h1 class="text-3xl font-semibold text-gray-900 dark:text-white mb-8">Publications</h1>
@@ -100,7 +100,7 @@
       <a href="{{ url_for('core.inspector') }}"
          class="px-5 py-2.5 text-sm font-medium rounded-lg border cursor-pointer text-blue-700 border-blue-700 hover:text-white hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:text-blue-500 dark:border-blue-500 dark:hover:text-white dark:hover:bg-blue-500 dark:focus:ring-blue-800 transition-colors inline-flex items-center gap-1.5">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3"/></svg>
-        Return to Inspector
+        Return to Infrastructure
       </a>
     </div>
   </div>


### PR DESCRIPTION
# Related Issues / Pull Requests

N/A

# Description

Renames all user-visible occurrences of "Inspector" to "Infrastructure" across the documentation and web frontend

# What changes are proposed in this pull request?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [X] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [X] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
