### PR TITLE
handle files with multi-row headers and merged cells

### DIFF
--- a/aidrin/file_handling/readers/excel_reader.py
+++ b/aidrin/file_handling/readers/excel_reader.py
@@ -1,8 +1,97 @@
+import os
+
+import openpyxl
 import pandas as pd
 
 from aidrin.file_handling.readers.base_reader import BaseFileReader
 
+_OPENPYXL_EXTENSIONS = {".xlsx", ".xlsm", ".xlsb"}
+
 
 class excelReader(BaseFileReader):
     def read(self):
-        return pd.read_excel(self.file_path)
+        ext = os.path.splitext(self.file_path)[1].lower()
+        if ext not in _OPENPYXL_EXTENSIONS:
+            return pd.read_excel(self.file_path)
+
+        wb = openpyxl.load_workbook(self.file_path, data_only=True)
+        ws = wb.active
+
+        num_header_rows = self._detect_header_rows(ws)
+        if num_header_rows == 1:
+            return pd.read_excel(self.file_path)
+
+        header_matrix = self._get_header_matrix(ws, num_header_rows)
+        flat_columns = self._flatten_header(header_matrix)
+        return pd.read_excel(
+            self.file_path,
+            skiprows=num_header_rows,
+            header=None,
+            names=flat_columns,
+        )
+
+    def _detect_header_rows(self, ws):
+        merged_ranges = list(ws.merged_cells.ranges)
+        if not merged_ranges:
+            return 1
+
+        # Only consider merged ranges that start in the top two rows.
+        top_merges = [r for r in merged_ranges if r.min_row <= 2]
+        if not top_merges:
+            return 1
+
+        max_merge_row = max(r.max_row for r in top_merges)
+        if max_merge_row > 1:
+            # A vertical/block merge already tells us the header depth.
+            return max_merge_row
+
+        # All merges are horizontal (within row 1 only). Check whether row 2
+        # also contains only string labels — if so it is the leaf-name row.
+        if self._row_looks_like_header(ws, 2):
+            return 2
+
+        return 1
+
+    def _row_looks_like_header(self, ws, row_num):
+        for cell in ws[row_num]:
+            if isinstance(cell, openpyxl.cell.cell.MergedCell):
+                continue
+            if cell.value is not None and not isinstance(cell.value, str):
+                return False
+        return True
+
+    def _get_header_matrix(self, ws, num_header_rows):
+        max_col = ws.max_column
+        matrix = [[None] * max_col for _ in range(num_header_rows)]
+
+        for row_idx in range(1, num_header_rows + 1):
+            for col_idx in range(1, max_col + 1):
+                cell = ws.cell(row=row_idx, column=col_idx)
+                if not isinstance(cell, openpyxl.cell.cell.MergedCell):
+                    matrix[row_idx - 1][col_idx - 1] = cell.value
+
+        for merge_range in ws.merged_cells.ranges:
+            if merge_range.min_row > num_header_rows:
+                continue
+            top_left_value = ws.cell(merge_range.min_row, merge_range.min_col).value
+            for r in range(merge_range.min_row, min(merge_range.max_row, num_header_rows) + 1):
+                for c in range(merge_range.min_col, merge_range.max_col + 1):
+                    matrix[r - 1][c - 1] = top_left_value
+
+        return matrix
+
+    def _flatten_header(self, matrix):
+        num_cols = len(matrix[0]) if matrix else 0
+        columns = []
+        for col_idx in range(num_cols):
+            seen = {}
+            parts = []
+            for row_idx in range(len(matrix)):
+                val = matrix[row_idx][col_idx]
+                if val is not None:
+                    label = str(val).strip()
+                    if label and label not in seen:
+                        parts.append(label)
+                        seen[label] = True
+            columns.append(" | ".join(parts) if parts else f"Column_{col_idx + 1}")
+        return columns

--- a/aidrin/file_handling/readers/excel_reader.py
+++ b/aidrin/file_handling/readers/excel_reader.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from aidrin.file_handling.readers.base_reader import BaseFileReader
 
-_OPENPYXL_EXTENSIONS = {".xlsx", ".xlsm", ".xlsb"}
+_OPENPYXL_EXTENSIONS = {".xlsx", ".xlsm"}
 
 
 class excelReader(BaseFileReader):

--- a/tests/unit/test_excel_reader.py
+++ b/tests/unit/test_excel_reader.py
@@ -1,0 +1,219 @@
+"""Unit tests for excelReader with multi-row / merged-cell header support.
+
+These tests run without Flask, Celery, or Redis.
+"""
+
+import logging
+import os
+import tempfile
+import unittest
+
+import openpyxl
+import pandas as pd
+
+from aidrin.file_handling.readers.excel_reader import excelReader
+
+_log = logging.getLogger("test")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _clean(path):
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _make_xlsx(setup_fn) -> str:
+    """Create a temp .xlsx file, call setup_fn(ws) to populate it, return path."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False)
+    tmp.close()
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    setup_fn(ws)
+    wb.save(tmp.name)
+    return tmp.name
+
+
+# ---------------------------------------------------------------------------
+# Single header row (fast path — no merged cells)
+# ---------------------------------------------------------------------------
+
+class TestExcelReaderSingleHeader(unittest.TestCase):
+
+    def test_reads_columns_and_rows(self):
+        def setup(ws):
+            ws.append(["Name", "Age", "Score"])
+            ws.append(["Alice", 25, 90.5])
+            ws.append(["Bob", 30, 85.0])
+
+        path = _make_xlsx(setup)
+        try:
+            df = excelReader(path, _log).read()
+        finally:
+            _clean(path)
+
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(list(df.columns), ["Name", "Age", "Score"])
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df["Name"].tolist(), ["Alice", "Bob"])
+
+    def test_single_header_no_merge_preserves_values(self):
+        def setup(ws):
+            ws.append(["X", "Y"])
+            ws.append([1, 2])
+            ws.append([3, 4])
+
+        path = _make_xlsx(setup)
+        try:
+            df = excelReader(path, _log).read()
+        finally:
+            _clean(path)
+
+        self.assertEqual(df["X"].tolist(), [1, 3])
+        self.assertEqual(df["Y"].tolist(), [2, 4])
+
+
+# ---------------------------------------------------------------------------
+# Two header rows: top row merged horizontally
+# ---------------------------------------------------------------------------
+
+class TestExcelReaderTwoRowHeader(unittest.TestCase):
+
+    def _make_demographics_xlsx(self):
+        """
+        Row 1: "Demographics" merged A1:C1 | "Info" merged D1:E1
+        Row 2: "Age" | "Gender" | "Race" | "Name" | "ID"
+        Data : 25, M, Asian, Alice, 1
+               30, F, White, Bob,   2
+        """
+        def setup(ws):
+            ws["A1"] = "Demographics"
+            ws.merge_cells("A1:C1")
+            ws["D1"] = "Info"
+            ws.merge_cells("D1:E1")
+            ws["A2"] = "Age"
+            ws["B2"] = "Gender"
+            ws["C2"] = "Race"
+            ws["D2"] = "Name"
+            ws["E2"] = "ID"
+            ws.append([25, "M", "Asian", "Alice", 1])
+            ws.append([30, "F", "White", "Bob", 2])
+
+        return _make_xlsx(setup)
+
+    def test_column_names_concatenated_with_separator(self):
+        path = self._make_demographics_xlsx()
+        try:
+            df = excelReader(path, _log).read()
+        finally:
+            _clean(path)
+
+        self.assertEqual(
+            list(df.columns),
+            [
+                "Demographics | Age",
+                "Demographics | Gender",
+                "Demographics | Race",
+                "Info | Name",
+                "Info | ID",
+            ],
+        )
+
+    def test_data_rows_loaded_correctly(self):
+        path = self._make_demographics_xlsx()
+        try:
+            df = excelReader(path, _log).read()
+        finally:
+            _clean(path)
+
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df["Demographics | Age"].tolist(), [25, 30])
+        self.assertEqual(df["Info | Name"].tolist(), ["Alice", "Bob"])
+
+
+# ---------------------------------------------------------------------------
+# Merged cell spanning both header rows (no duplication in flattened name)
+# ---------------------------------------------------------------------------
+
+class TestExcelReaderMergeSpansBothRows(unittest.TestCase):
+
+    def test_vertically_merged_header_cell_not_duplicated(self):
+        """
+        Row 1: "ID" merged A1:A2 | "Score" in B1
+        Row 2: (A2 is part of merge)  | "Points" in B2
+        Expected columns: ["ID", "Score | Points"]
+        """
+        def setup(ws):
+            ws["A1"] = "ID"
+            ws.merge_cells("A1:A2")
+            ws["B1"] = "Score"
+            ws["B2"] = "Points"
+            ws.append([1, 95])
+            ws.append([2, 88])
+
+        path = _make_xlsx(setup)
+        try:
+            df = excelReader(path, _log).read()
+        finally:
+            _clean(path)
+
+        self.assertIn("ID", df.columns)
+        self.assertNotIn("ID | ID", df.columns)
+        self.assertIn("Score | Points", df.columns)
+
+    def test_vertically_merged_cell_data_correct(self):
+        def setup(ws):
+            ws["A1"] = "ID"
+            ws.merge_cells("A1:A2")
+            ws["B1"] = "Value"
+            ws["B2"] = "Raw"
+            ws.append([10, 99])
+            ws.append([20, 77])
+
+        path = _make_xlsx(setup)
+        try:
+            df = excelReader(path, _log).read()
+        finally:
+            _clean(path)
+
+        self.assertEqual(df["ID"].tolist(), [10, 20])
+
+
+# ---------------------------------------------------------------------------
+# Fallback: .xls extension skips openpyxl and delegates to pandas
+# ---------------------------------------------------------------------------
+
+class TestExcelReaderXlsFallback(unittest.TestCase):
+
+    def test_xls_path_uses_pandas_fallback(self):
+        """
+        excelReader with a .xls path should not raise AttributeError or
+        openpyxl-specific errors — it falls back to pd.read_excel().
+        We use an xlsx file renamed to .xls to verify the code path branches
+        without needing the legacy xlrd engine.
+        """
+        def setup(ws):
+            ws.append(["A", "B"])
+            ws.append([1, 2])
+
+        xlsx_path = _make_xlsx(setup)
+        xls_path = xlsx_path.replace(".xlsx", ".xls")
+        os.rename(xlsx_path, xls_path)
+        try:
+            # Should not crash with an openpyxl-specific error;
+            # pandas may raise an engine error for a mis-named file,
+            # but the branching logic itself must not raise AttributeError.
+            try:
+                excelReader(xls_path, _log).read()
+            except Exception as exc:
+                self.assertNotIsInstance(exc, AttributeError)
+        finally:
+            _clean(xls_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Related Issues / Pull Requests

Fix [issue](https://github.com/idtlab/AIDRIN/issues/119)

# Description

Excel file reader was previously called with no options, so XLSX files with multi-row headers and merged cells were read incorrectly. Merged cell values were dropped, and the second header row was treated as data. This change auto-detect multi-row headers and forward-fill merged cell values, then flattens the resulting column names using a `" | "` separator. The Excel files attached to the original [issue](https://github.com/idtlab/AIDRIN/issues/119) were used to verify that the new parsing logic correctly handles these cases.

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
