### PR TITLE
Fix Data Overview panel for datasets with no numerical features

### DIFF
--- a/tests/integration/test_summary_statistics.py
+++ b/tests/integration/test_summary_statistics.py
@@ -1,0 +1,61 @@
+"""Regression test for issue #125.
+
+The Data Overview panel (/summary-statistics) must load when the uploaded
+dataset has no numerical features. Previously df.describe() fell back to
+object-column stats and the numeric formatter raised
+``TypeError: bad operand type for abs(): 'str'``.
+"""
+
+
+def _upload(client, tmp_path, content, name="all_strings.csv", ftype=".csv"):
+    path = tmp_path / name
+    path.write_text(content)
+    with open(path, "rb") as f:
+        resp = client.post(
+            "/inspector",
+            data={"file": (f, name), "fileTypeSelector": ftype},
+            content_type="multipart/form-data",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    return client
+
+
+def test_summary_statistics_all_categorical(client, tmp_path):
+    _upload(
+        client,
+        tmp_path,
+        "name,department,level\nAlice,Engineering,Senior\nBob,Sales,Junior\n",
+    )
+
+    resp = client.get("/summary-statistics")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    # The panel must succeed, not fall back to the generic error handler.
+    assert data["success"] is True
+    # Record/feature counts still appear.
+    assert data["records_count"] == 2
+    assert data["features_count"] == 3
+    # No numerical features -> empty numerical summary, rest of panel intact.
+    assert data["numerical_features"] == []
+    assert data["summary_statistics"] == {}
+    assert sorted(data["categorical_features"]) == ["department", "level", "name"]
+
+
+def test_summary_statistics_mixed_still_works(client, tmp_path):
+    # A mix of numeric + categorical still reports numeric stats as before.
+    _upload(
+        client,
+        tmp_path,
+        "name,age,score\nAlice,25,90.5\nBob,30,85.0\n",
+        name="mixed.csv",
+    )
+
+    resp = client.get("/summary-statistics")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert sorted(data["numerical_features"]) == ["age", "score"]
+    assert "age" in data["summary_statistics"]
+    assert data["categorical_features"] == ["name"]

--- a/web/globus.py
+++ b/web/globus.py
@@ -104,9 +104,16 @@ def remote_metric_runner(metric_name, file_path, file_name, file_type, **params)
         ]
         all_features = numerical_columns + categorical_columns
 
-        summary = df.describe().map(
-            lambda x: round(x, 2) if x == 0 or abs(x) >= 0.001 else f"{x:.2e}"
-        ).to_dict()
+        # Restrict to numeric columns: describe() would otherwise fall back to
+        # object-column stats (top/freq are strings) and the numeric formatter
+        # below would fail on them when there are no numerical features (#125).
+        numeric_df = df.select_dtypes(include="number")
+        if numeric_df.shape[1] == 0:
+            summary = {}
+        else:
+            summary = numeric_df.describe().map(
+                lambda x: round(x, 2) if x == 0 or abs(x) >= 0.001 else f"{x:.2e}"
+            ).to_dict()
 
         # Rename percentile keys
         for v in summary.values():

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -337,9 +337,17 @@ def summary_statistics():
         if load_error:
             return jsonify({"success": False, "message": load_error}), 200
 
-        summary_statistics = df.describe().map(
-            lambda x: round(x, 2) if x == 0 or abs(x) >= 0.001 else f"{x:.2e}"
-        ).to_dict()
+        # Restrict to numeric columns: describe() would otherwise fall back to
+        # object-column stats (top/freq are strings) and the numeric formatter
+        # below would fail on them. Datasets with no numerical features simply
+        # get an empty numerical summary (issue #125).
+        numeric_df = df.select_dtypes(include="number")
+        if numeric_df.shape[1] == 0:
+            summary_statistics = {}
+        else:
+            summary_statistics = numeric_df.describe().map(
+                lambda x: round(x, 2) if x == 0 or abs(x) >= 0.001 else f"{x:.2e}"
+            ).to_dict()
 
         histograms = summary_histograms(df)
 


### PR DESCRIPTION
## Summary

Fixes #125. Uploading a dataset with **no numerical features** (all columns categorical/text) broke the **Data Overview** panel with:

```
TypeError: bad operand type for abs(): 'str'
```

`df.describe()` falls back to **object-column** statistics (`top`, `freq` are strings) when there are no numeric columns, and the numeric formatter then ran `abs()` on those strings.

## Fix

Restrict `describe()` to numeric columns (the same `select_dtypes(include="number")` pattern `summary_histograms` already uses) and return an empty numerical summary when there are none:

```python
numeric_df = df.select_dtypes(include="number")
if numeric_df.shape[1] == 0:
    summary_statistics = {}
else:
    summary_statistics = numeric_df.describe().map(...).to_dict()
```

Applied to **both** affected paths:
- `web/routes/core.py` — the standard `/summary-statistics` panel.
- `web/globus.py` — the Globus remote-summary path (identical bug).

Record/feature counts, categorical features, and histograms still load — matching the issue's expected behavior.

## Frontend

No JS change needed — verified the panel renderer already degrades cleanly for the empty case: `summary_statistics: {}` is guarded by `features.length > 0` (empty table), `numerical_features: []` shows "No features available", and `histograms: {}` clears the container.

## Tests

- New `tests/integration/test_summary_statistics.py`: an all-categorical upload reproduced the exact traceback (failed before, passes after); a second test confirms mixed numeric+categorical still reports numeric stats.
- Full suite: **317 passed**, no regressions.

## To reproduce

Upload an all-string dataset, e.g.:
```json
[{"name": "Alice", "department": "Engineering", "level": "Senior"},
 {"name": "Bob", "department": "Sales", "level": "Junior"}]
```