### PR TITLE
Wire HIPAA checks to CLI and MCP server

### DIFF
--- a/.claude/skills/aidrin/SKILL.md
+++ b/.claude/skills/aidrin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aidrin
-description: Use when the user asks "is my data AI ready", "is my dataset ready", "what is the quality of my data", whether data is good enough to train or publish, to check a dataset for bias, fairness, privacy, PII risk, class imbalance, duplicates, outliers, completeness, feature relevance, k-anonymity, or mentions AIDRIN. Supports CSV, Excel (.xls/.xlsb/.xlsx/.xlsm), JSON, NumPy (.npz), HDF5 (.h5), and Parquet files.
+description: Use when the user asks "is my data AI ready", "is my dataset ready", "what is the quality of my data", whether data is good enough to train or publish, to check a dataset for bias, fairness, privacy, PII risk, HIPAA compliance, protected health information, PHI, class imbalance, duplicates, outliers, completeness, feature relevance, k-anonymity, or mentions AIDRIN. Supports CSV, Excel (.xls/.xlsb/.xlsx/.xlsm), JSON, NumPy (.npz), HDF5 (.h5), and Parquet files.
 ---
 
 # Assessing dataset AI-readiness with AIDRIN
@@ -75,11 +75,12 @@ Dimension → metric mapping for focused requests:
 
 | Stated dimension | Metrics to run |
 |---|---|
-| Fairness / bias | class_imbalance, statistical_rates, representation_rate |
-| Privacy / PII / anonymity | k_anonymity, l_diversity, t_closeness, entropy_risk, single_attribute_risk, multiple_attribute_risk |
+| Fairness / bias | class-imbalance, statistical-rates, representation-rate |
+| Privacy / PII / anonymity | k-anonymity, l-diversity, t-closeness, entropy-risk, single-attribute-risk, multiple-attribute-risk |
+| HIPAA / PHI compliance | hipaa-compliance |
 | Data quality / completeness / duplicates / outliers | completeness, duplicity, outliers |
-| Feature relevance / AI impact | feature_relevance, correlations |
-| Class imbalance | class_imbalance |
+| Feature relevance / AI impact | feature-relevance, correlations |
+| Class imbalance | class-imbalance |
 | Full readiness (no specific dimension) | all applicable metrics per the intent table in Step 4 |
 
 Always add the zero-arg quality baseline (completeness, duplicity, outliers) even for
@@ -103,16 +104,13 @@ include the zero-arg quality baseline.
 
 | User intent | Metrics | Columns needed |
 |---|---|---|
-| Train supervised model | completeness, duplicity, outliers, feature_relevance, class_imbalance, correlations | target; categorical/numerical features; correlations & feature_relevance need columns |
-| Ensure fairness across groups | class_imbalance, statistical_rates, representation_rate | target + sensitive attribute(s) |
-| Publish / share externally | k_anonymity, l_diversity, t_closeness, entropy_risk, single_attribute_risk, multiple_attribute_risk | quasi-identifiers, sensitive column, id column + eval columns |
+| Train supervised model | completeness, duplicity, outliers, feature-relevance, class-imbalance, correlations | target; categorical/numerical features; correlations & feature-relevance need columns |
+| Ensure fairness across groups | class-imbalance, statistical-rates, representation-rate | target + sensitive attribute(s) |
+| Publish / share externally | k-anonymity, l-diversity, t-closeness, entropy-risk, single-attribute-risk, multiple-attribute-risk | quasi-identifiers, sensitive column, id column + eval columns |
 | General quality / exploration | completeness, duplicity, outliers, correlations | correlations needs columns |
-| Contains PII / sensitive data | governance + privacy set above | quasi-identifiers, sensitive column |
+| Contains PII / sensitive data | governance + privacy set above, hipaa-compliance | quasi-identifiers, sensitive column; hipaa-compliance needs columns to scan |
 
 Always-run baseline (zero-arg): completeness, duplicity, outliers.
-
-_Names above are readable labels. MCP uses underscore form (`class_imbalance`);
-CLI `aidrin run` uses dash form (`class-imbalance`). See [reference/metrics.md](reference/metrics.md)._
 
 ### 5. Confirm the plan (HARD gate)
 
@@ -131,14 +129,14 @@ casing / non-existent columns before running.
 
 **MCP path (preferred):**
 - Zero-arg baseline: one call — `run_data_quality_check(file_path="...")` runs completeness, duplicity, and outliers together.
-- Per metric: `run_aidrin_metric(file_path="...", metric="class_imbalance", target_column="income")`. Use **underscore form** for metric names. All column args are named kwargs — no positional ordering to worry about.
+- Per metric: `run_aidrin_metric(file_path="...", metric="class-imbalance", target_column="income")`. All column args are named kwargs — no positional ordering to worry about.
 - If a metric fails, its returned JSON contains an `Error`/`ErrorType` key. Record it as "Not run: <reason>" and continue with the rest.
 
 **CLI path (fallback):**
 - Default: one `aidrin run <metric> <file> <args...>` per metric. This isolates errors.
 - Batch the zero-arg baseline: `aidrin batch <config>` with `{"file_path": "...", "metrics": ["completeness","duplicity","outliers"]}`.
 - NOTE: `aidrin run` exits 0 even on failure — detect failures by checking the JSON output for an `Error`/`ErrorType` key, not the exit code.
-- Metric names under `aidrin run` are **dash form** (`class-imbalance`, `k-anonymity`). Underscore forms are rejected. Args are positional — see [reference/metrics.md](reference/metrics.md) for order.
+- Args are positional — see [reference/metrics.md](reference/metrics.md) for order.
 
 ### 8. Write the report
 
@@ -300,13 +298,11 @@ Returns combined JSON: `profile` + `queries` (one entry per question: retrieval,
 ## Gotchas
 
 **MCP:**
-- Metric names in `run_aidrin_metric` use **underscore form** (`class_imbalance`, `k_anonymity`). `list_metrics()` returns **dash form** names (`class-imbalance`, `k-anonymity`) — convert dashes to underscores before passing to `run_aidrin_metric`. Dash form raises `ValueError: Unknown metric`.
 - `run_data_quality_check` and `run_aidrin_metric` suppress image writes internally (`save_images=False`). No workaround needed.
 - Failures surface as `Error`/`ErrorType` keys in the returned JSON — not as raised exceptions.
 
 **CLI:**
 - `aidrin run` returns exit 0 even when a metric fails; detect failures via `Error`/`ErrorType` in the JSON output.
-- Metric names under `aidrin run` are **dash form** (`class-imbalance`, not `class_imbalance`). Underscore forms are rejected.
 - Per-metric args are **positional**, in the order shown by `aidrin run <metric> -h`. NOT `--flags`. Quote comma-separated column lists: `"zip,age"`.
 - `aidrin run` writes visualization PNGs to `/tmp/aidrin_images` by default. Suppress via `aidrin batch` with `"save-images": false`.
 - If `aidrin` is not on PATH, see [reference/installation.md](reference/installation.md).

--- a/.claude/skills/aidrin/reference/metrics.md
+++ b/.claude/skills/aidrin/reference/metrics.md
@@ -4,10 +4,10 @@
 
 - [Invocation & conventions](#invocation--conventions)
 - [Data quality](#data-quality): completeness, duplicity, outliers
-- [Impact on AI](#impact-on-ai): correlations, feature_relevance
-- [Fairness & bias](#fairness--bias): class_imbalance, statistical_rates, representation_rate
-- [Data governance](#data-governance): k_anonymity, l_diversity, t_closeness, entropy_risk, single_attribute_risk, multiple_attribute_risk
-- [Privacy](#privacy): differential_privacy (currently unavailable)
+- [Impact on AI](#impact-on-ai): correlations, feature-relevance
+- [Fairness & bias](#fairness--bias): class-imbalance, statistical-rates, representation-rate
+- [Data governance](#data-governance): k-anonymity, l-diversity, t-closeness, entropy-risk, single-attribute-risk, multiple-attribute-risk, hipaa-compliance
+- [Privacy](#privacy): differential-privacy (currently unavailable)
 - [Batch config format](#batch-config-format)
 
 ---
@@ -16,9 +16,6 @@
 
 - `aidrin run <metric> <file> <args...>` — args are POSITIONAL, in the order
   shown by `aidrin run <metric> -h`. NOT `--flags`.
-- Metric names use **dash form** under `aidrin run` (`class-imbalance`,
-  `feature-relevance`, `k-anonymity`, etc.). Underscore forms are NOT accepted by
-  `aidrin run`.
 - Column lists are comma-separated strings; quote them: `"col_a,col_b"`.
 - `--detail` defaults on for `run`/`batch` (full JSON). Visualizations are
   stripped by default.
@@ -101,7 +98,7 @@ aidrin run correlations examples/sample_data/csv/adult.csv "age,education.num"
 
 ---
 
-### feature_relevance
+### feature-relevance
 
 - **Syntax:** `aidrin run feature-relevance <file> [categorical-columns] [numerical-columns] <target-column>`
 - **Args (in order):**
@@ -125,7 +122,7 @@ aidrin run feature-relevance examples/sample_data/csv/adult.csv \
 
 ## Fairness & bias
 
-### class_imbalance
+### class-imbalance
 
 - **Syntax:** `aidrin run class-imbalance <file> <target-column>`
 - **Args (in order):**
@@ -144,7 +141,7 @@ aidrin run class-imbalance examples/sample_data/csv/adult.csv income
 
 ---
 
-### statistical_rates
+### statistical-rates
 
 - **Syntax:** `aidrin run statistical-rates <file> <y-true-column> <sensitive-attribute-column>`
 - **Args (in order):**
@@ -164,7 +161,7 @@ aidrin run statistical-rates examples/sample_data/csv/adult.csv income sex
 
 ---
 
-### representation_rate
+### representation-rate
 
 - **Syntax:** `aidrin run representation-rate <file> "<columns>"`
 - **Args (in order):**
@@ -184,7 +181,7 @@ aidrin run representation-rate examples/sample_data/csv/adult.csv "sex,race"
 
 ## Data governance
 
-### k_anonymity
+### k-anonymity
 
 - **Syntax:** `aidrin run k-anonymity <file> "<quasi-identifiers>"`
 - **Args (in order):**
@@ -202,7 +199,7 @@ aidrin run k-anonymity examples/sample_data/csv/adult.csv "age,sex,race"
 
 ---
 
-### l_diversity
+### l-diversity
 
 - **Syntax:** `aidrin run l-diversity <file> "<quasi-identifiers>" <sensitive-column>`
 - **Args (in order):**
@@ -221,7 +218,7 @@ aidrin run l-diversity examples/sample_data/csv/adult.csv "age,sex,race" income
 
 ---
 
-### t_closeness
+### t-closeness
 
 - **Syntax:** `aidrin run t-closeness <file> "<quasi-identifiers>" <sensitive-column>`
 - **Args (in order):**
@@ -240,7 +237,7 @@ aidrin run t-closeness examples/sample_data/csv/adult.csv "age,sex,race" income
 
 ---
 
-### entropy_risk
+### entropy-risk
 
 - **Syntax:** `aidrin run entropy-risk <file> "<quasi-identifiers>"`
 - **Args (in order):**
@@ -258,7 +255,7 @@ aidrin run entropy-risk examples/sample_data/csv/adult.csv "age,sex,race"
 
 ---
 
-### single_attribute_risk
+### single-attribute-risk
 
 - **Syntax:** `aidrin run single-attribute-risk <file> <id-column> "<eval-columns>"`
 - **Args (in order):**
@@ -279,7 +276,7 @@ aidrin run single-attribute-risk examples/sample_data/csv/adult.csv ID "age,occu
 
 ---
 
-### multiple_attribute_risk
+### multiple-attribute-risk
 
 - **Syntax:** `aidrin run multiple-attribute-risk <file> <id-column> "<eval-columns>"`
 - **Args (in order):**
@@ -301,9 +298,30 @@ aidrin run multiple-attribute-risk examples/sample_data/csv/adult.csv ID "age,oc
 
 ---
 
+### hipaa-compliance
+
+- **Syntax:** `aidrin run hipaa-compliance <file> "<columns>"`
+- **Args (in order):**
+  1. `columns` — comma-separated columns to scan for HIPAA-regulated PHI patterns
+- **Output keys:** one entry per column where at least one match was found (columns with no matches are omitted; no matches anywhere returns `{}`):
+  - `<column_name>.total_flags` — int; count of matched values in that column
+  - `<column_name>.potential_types_detected` — array; identifier types found, e.g. `US_SSN`, `EMAIL_ADDRESS`, `PHONE_OR_FAX`, `IP_ADDRESS`, `URL`, `VIN_NUMBER`, `MEDICAL_IDS`, `VALID_POSTAL_CODE`
+  - `<column_name>.examples` — array; up to 5 example matched values
+- **Direction:** any flags present = potential HIPAA-regulated PHI in that column; an empty `{}` result means none of the scanned columns matched. Postal codes are validated against a real geocode database (pgeocode, US by default) rather than a bare 5-digit regex, to cut down false positives.
+
+**Example:**
+
+```bash
+aidrin run hipaa-compliance examples/sample_data/csv/adult.csv "native.country,fnlwgt"
+```
+
+Note: this is regex/pattern-based PHI detection (SSN, email, phone, IP, URL, VIN, medical IDs, postal codes) — not a full HIPAA Safe Harbor 18-identifier audit. Treat findings as leads to review, not a compliance certification.
+
+---
+
 ## Privacy
 
-### differential_privacy
+### differential-privacy
 
 - **Syntax:** `aidrin run differential-privacy <file> "<columns>" <epsilon>`
 - **Args (in order):**
@@ -332,23 +350,23 @@ aidrin run differential-privacy examples/sample_data/csv/adult.csv "age,hours.pe
 column keys is applied to every metric listed in `metrics`. Use batch only for
 metrics that share identical args (e.g. the zero-arg quality baseline).
 
-Config keys use dash names (underscore forms are also accepted in batch config). Set `"save-images": false` to suppress the PNG writes that `aidrin run` produces by default:
+Config keys use dash names. Set `"save-images": false` to suppress the PNG writes that `aidrin run` produces by default:
 
 | Key                          | Used by metric(s)                              |
 |------------------------------|------------------------------------------------|
 | `file_path`                  | all                                            |
 | `metrics`                    | all (list of metric names)                     |
-| `target-column`              | class_imbalance, feature_relevance             |
-| `quasi-identifiers`          | k_anonymity, l_diversity, t_closeness, entropy_risk |
-| `sensitive-column`           | l_diversity, t_closeness                       |
-| `sensitive-attribute-column` | statistical_rates                              |
-| `y-true-column`              | statistical_rates                              |
-| `categorical-columns`        | feature_relevance                              |
-| `numerical-columns`          | feature_relevance                              |
-| `id-column`                  | single_attribute_risk, multiple_attribute_risk |
-| `eval-columns`               | single_attribute_risk, multiple_attribute_risk |
-| `columns`                    | correlations, representation_rate              |
-| `epsilon`                    | differential_privacy                           |
+| `target-column`              | class-imbalance, feature-relevance             |
+| `quasi-identifiers`          | k-anonymity, l-diversity, t-closeness, entropy-risk |
+| `sensitive-column`           | l-diversity, t-closeness                       |
+| `sensitive-attribute-column` | statistical-rates                              |
+| `y-true-column`              | statistical-rates                              |
+| `categorical-columns`        | feature-relevance                              |
+| `numerical-columns`          | feature-relevance                              |
+| `id-column`                  | single-attribute-risk, multiple-attribute-risk |
+| `eval-columns`               | single-attribute-risk, multiple-attribute-risk |
+| `columns`                    | correlations, representation-rate              |
+| `epsilon`                    | differential-privacy                           |
 | `save-images`                | any metric that produces visualizations        |
 
 **Example — zero-arg quality baseline (all three share no required column args):**
@@ -362,11 +380,11 @@ Config keys use dash names (underscore forms are also accepted in batch config).
 ```json
 {
   "file_path": "data.csv",
-  "metrics": ["k_anonymity", "l_diversity", "t_closeness", "entropy_risk"],
+  "metrics": ["k-anonymity", "l-diversity", "t-closeness", "entropy-risk"],
   "quasi-identifiers": "age,sex,race",
   "sensitive-column": "income"
 }
 ```
 
-Note: `entropy_risk` ignores `sensitive-column` (it takes only `quasi-identifiers`);
+Note: `entropy-risk` ignores `sensitive-column` (it takes only `quasi-identifiers`);
 the extra key is silently ignored by batch.

--- a/aidrin/headless/api.py
+++ b/aidrin/headless/api.py
@@ -385,7 +385,7 @@ def run_metric(
     strip_visualizations: bool = False,
     **kwargs: Any,
 ) -> Dict[str, Any]:
-    metric_key = metric_name.strip().lower()
+    metric_key = metric_name.strip().lower().replace("-", "_")
     metric = METRIC_REGISTRY.get(metric_key)
     if not metric:
         # Try resolving as a custom metric

--- a/aidrin/headless/api.py
+++ b/aidrin/headless/api.py
@@ -18,6 +18,7 @@ from .runners import (
     run_duplicity,
     run_entropy_risk,
     run_feature_relevance,
+    run_hipaa_compliance,
     run_k_anonymity,
     run_l_diversity,
     run_multiple_attribute_risk,
@@ -119,6 +120,12 @@ METRIC_REGISTRY: Dict[str, Dict[str, Any]] = {
         "description": "Differentially private noise statistics for selected columns.",
         "runner": run_differential_privacy,
         "required_args": ["columns", "epsilon"],
+    },
+    "hipaa_compliance": {
+        "category": "data-governance",
+        "description": "Scan columns for HIPAA-regulated PHI (SSN, email, phone, IP, URLs, medical IDs, postal codes).",
+        "runner": run_hipaa_compliance,
+        "required_args": ["columns"],
     },
 }
 
@@ -504,6 +511,13 @@ def run_metric(
         if not columns or epsilon is None:
             raise ValueError("columns and epsilon are required for differential_privacy")
         result = metric["runner"](file_path, file_type, file_name, columns, epsilon)
+        return _finalize(result)
+
+    if metric_key == "hipaa_compliance":
+        columns = _normalize_list(kwargs.get("columns"))
+        if not columns:
+            raise ValueError("columns is required for hipaa_compliance")
+        result = metric["runner"](file_path, file_type, file_name, columns)
         return _finalize(result)
 
     raise ValueError(f"Unsupported metric: {metric_name}")

--- a/aidrin/headless/cli.py
+++ b/aidrin/headless/cli.py
@@ -118,6 +118,13 @@ def _summarize_metric(metric_name: str, result: dict) -> None:
             print(f"Outliers ({n} features): {_fmt(overall)}  (max: {_fmt(mx)}, >5%: {high}/{n})")
         else:
             print(f"Outliers: {_fmt(overall)}")
+    elif metric_name == "hipaa_compliance":
+        if not result:
+            print("No PHI detected.")
+        else:
+            for col, findings in result.items():
+                types_str = ", ".join(findings.get("potential_types_detected", []))
+                print(f"{col}: {findings.get('total_flags', 0)} flag(s)  [{types_str}]")
     else:
         # Generic: print top-level keys with scalar values, count dict/list values
         for k, v in result.items():

--- a/aidrin/headless/cli.py
+++ b/aidrin/headless/cli.py
@@ -424,7 +424,7 @@ def main() -> None:
     if argv:
         metric_key = argv[0].replace("-", "_")
         if metric_key in METRIC_REGISTRY:
-            argv = ["run", metric_key] + argv[1:]
+            argv = ["run", metric_key.replace("_", "-")] + argv[1:]
     args = parser.parse_args(argv)
 
     try:

--- a/aidrin/headless/runners.py
+++ b/aidrin/headless/runners.py
@@ -26,6 +26,7 @@ from aidrin.structured_data_metrics.representation_rate import (
     calculate_representation_rate,
     create_representation_rate_vis,
 )
+from aidrin.structured_data_metrics.hipaa_compliance import detect_hipaa_identifiers
 from aidrin.structured_data_metrics.statistical_rate import calculate_statistical_rates
 
 # Signal metrics to skip chart generation in headless mode
@@ -277,6 +278,17 @@ def run_multiple_attribute_risk(
     file_info = _build_file_info(file_path, file_type, file_name)
     data = read_file(file_info)
     return generate_multiple_attribute_MM_risk_scores(data, id_column, eval_columns, NullTask())
+
+
+def run_hipaa_compliance(
+    file_path: str,
+    file_type: Optional[str],
+    file_name: Optional[str],
+    columns: List[str],
+) -> Dict[str, Any]:
+    file_info = _build_file_info(file_path, file_type, file_name)
+    df = read_file(file_info)
+    return detect_hipaa_identifiers(df, columns)
 
 
 def _dp_error_payload(error_message: str) -> Dict[str, Any]:

--- a/aidrin/mcp/server.py
+++ b/aidrin/mcp/server.py
@@ -114,7 +114,7 @@ def run_aidrin_metric(
         file_path: Absolute path to the dataset.
         metric: Metric name, e.g. completeness, k_anonymity, class_imbalance.
         file_type: File-type override.
-        columns: Comma-separated columns (required by: correlations, representation_rate).
+        columns: Comma-separated columns (required by: correlations, representation_rate, hipaa_compliance).
         target_column: Target/label column (required by: class_imbalance, feature_relevance).
         cat_columns: Comma-separated categorical columns (feature_relevance).
         num_columns: Comma-separated numerical columns (feature_relevance).

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -123,6 +123,7 @@ Examples:
    aidrin run l-diversity /path/to/sample_dataset.csv "age,zipcode" diagnosis
    aidrin run t-closeness /path/to/sample_dataset.csv "age,zipcode" diagnosis
    aidrin run entropy-risk /path/to/sample_dataset.csv "age,zipcode,gender"
+   aidrin run hipaa-compliance /path/to/sample_dataset.csv "age,zipcode,diagnosis"
 
 Options available on all ``run`` subcommands:
 
@@ -265,6 +266,9 @@ Available Metrics
    * - Data Governance
      - ``multiple-attribute-risk``
      - ``id-column``, ``eval-columns``
+   * - Data Governance
+     - ``hipaa-compliance``
+     - ``columns``
    * - Custom
      - ``custom``
      - ``<name-or-path>``, varies — see ``aidrin run custom -h``

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -269,6 +269,119 @@ class TestRunCommand(unittest.TestCase):
         _, _, code = _run_cli("completeness", self.csv)
         self.assertEqual(code, 0)
 
+    # --- hipaa-compliance wiring ------------------------------------------
+
+    def test_run_hipaa_compliance_exits_zero(self):
+        _, _, code = _run_cli("run", "hipaa-compliance", self.csv, "age,income,sex")
+        self.assertEqual(code, 0)
+
+    def test_run_hipaa_compliance_no_phi_returns_empty(self):
+        # age (2-digit) and sex (M/F) match no PHI pattern. NB: income is
+        # deliberately excluded — 5-digit incomes can match the postal-code
+        # candidate regex and validate as real ZIPs (a detector false positive).
+        stdout, _, _ = _run_cli("run", "hipaa-compliance", self.csv, "age,sex")
+        self.assertEqual(json.loads(stdout), {})
+
+    def test_run_hipaa_compliance_detects_phi(self):
+        csv = _write_csv(pd.DataFrame({
+            "contact": ["a@b.com", "c@d.org"],
+            "age": [30, 40],
+        }))
+        try:
+            stdout, _, code = _run_cli("run", "hipaa-compliance", csv, "contact")
+            self.assertEqual(code, 0)
+            data = json.loads(stdout)
+            self.assertIn("contact", data)
+            self.assertIn("EMAIL_ADDRESS", data["contact"]["potential_types_detected"])
+        finally:
+            _clean(csv)
+
+    def test_shortcut_multiword_metric(self):
+        """aidrin hipaa-compliance <file> ... routes to `run` (guards the
+        multi-word shortcut fix: the old code passed underscore form to the
+        dash-only `run` subparser and errored)."""
+        _, _, code = _run_cli("hipaa-compliance", self.csv, "age,income,sex")
+        self.assertEqual(code, 0)
+
+    def test_shortcut_underscore_form_resolves(self):
+        """Underscore shortcut form also resolves after dash normalization."""
+        _, _, code = _run_cli("hipaa_compliance", self.csv, "age,income,sex")
+        self.assertEqual(code, 0)
+
+
+# ===========================================================================
+# hipaa summary line (_summarize_metric)
+# ===========================================================================
+
+
+class TestSummarizeHipaa(unittest.TestCase):
+
+    def _capture(self, metric_name: str, result: dict) -> str:
+        from aidrin.headless.cli import _summarize_metric
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            _summarize_metric(metric_name, result)
+        return buf.getvalue()
+
+    def test_no_phi_message(self):
+        out = self._capture("hipaa_compliance", {})
+        self.assertIn("No PHI detected", out)
+
+    def test_findings_printed(self):
+        out = self._capture("hipaa_compliance", {
+            "contact": {
+                "total_flags": 2,
+                "potential_types_detected": ["EMAIL_ADDRESS"],
+                "examples": ["a@b.com"],
+            },
+        })
+        self.assertIn("contact", out)
+        self.assertIn("2 flag", out)
+        self.assertIn("EMAIL_ADDRESS", out)
+
+
+# ===========================================================================
+# run_metric metric-name resolution (dash / underscore)
+# ===========================================================================
+
+
+class TestRunMetricNameResolution(unittest.TestCase):
+
+    def setUp(self):
+        self.csv = _write_csv(_sample_df())
+
+    def tearDown(self):
+        _clean(self.csv)
+
+    def test_hipaa_in_registry(self):
+        from aidrin.headless.api import METRIC_REGISTRY
+        self.assertIn("hipaa_compliance", METRIC_REGISTRY)
+
+    def test_dash_form_resolves(self):
+        from aidrin.headless.api import run_metric
+        result = run_metric(
+            "hipaa-compliance", self.csv, columns="age,income,sex", save_images=False
+        )
+        self.assertIsInstance(result, dict)
+
+    def test_underscore_form_resolves(self):
+        from aidrin.headless.api import run_metric
+        result = run_metric(
+            "hipaa_compliance", self.csv, columns="age,income,sex", save_images=False
+        )
+        self.assertIsInstance(result, dict)
+
+    def test_dash_and_underscore_equivalent(self):
+        from aidrin.headless.api import run_metric
+        dash = run_metric("hipaa-compliance", self.csv, columns="age", save_images=False)
+        under = run_metric("hipaa_compliance", self.csv, columns="age", save_images=False)
+        self.assertEqual(dash, under)
+
+    def test_missing_columns_raises(self):
+        from aidrin.headless.api import run_metric
+        with self.assertRaises(ValueError):
+            run_metric("hipaa-compliance", self.csv, save_images=False)
+
 
 # ===========================================================================
 # add-custom-module command


### PR DESCRIPTION
# Related Issues / Pull Requests

NA

# Description

Wires the existing `hipaa_compliance` PHI detector  into the headless API, CLI, and MCP server as a first-class metric, alongside a small fix that normalizes dash/underscore metric-name handling so both forms resolve consistently across entry points.

# What changes are proposed in this pull request?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [X] This change requires a documentation update

# Checklist:

- [X] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
