### PR TITLE
Pin NERSC image to Python 3.13.11

### DIFF
--- a/docker/NERSC/Dockerfile
+++ b/docker/NERSC/Dockerfile
@@ -1,7 +1,8 @@
 # AIDRIN image for NERSC Spin: web + worker + beat under supervisord; Redis is separate.
 # Build from repo root: docker build -f docker/NERSC/Dockerfile -t aidrin:latest .
 # Runs Celery beat, so deploy with exactly ONE replica.
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+FROM python:3.13.11-slim-bookworm AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.9.27 /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -17,7 +18,7 @@ COPY . .
 RUN uv sync --frozen --no-dev $AIDRIN_EXTRAS
 RUN uv pip install gunicorn==23.0.0 supervisor==4.2.5
 
-FROM python:3.12-slim-bookworm
+FROM python:3.13.11-slim-bookworm
 
 # libgomp1: OpenMP runtime for scikit-learn/scipy/shap.
 RUN apt-get update \


### PR DESCRIPTION
## Summary

Pins the NERSC Spin image to Python 3.13.11 (was 3.12).

Both stages now build on `python:3.13.11-slim-bookworm`, with the `uv` binary copied in
from its own image. Basing the builder and the runtime on the same image keeps the
interpreter identical across stages, so the virtualenv stays portable and the patch
version is pinned exactly rather than floating on the latest 3.12.x.

3.13 is within AIDRIN's supported range (3.10-3.13) and `uv.lock` already resolves for it.

## Verification

- Image builds for linux/amd64 and reports Python 3.13.11.
- The `llm` and `globus` extras still install and import (openai 2.38.0, globus-sdk 4.7.0,
  globus-compute-sdk 4.12.0); OpenTelemetry remains absent, as intended for NERSC.
- Published as `registry.nersc.gov/m1248/aidrin:v2026.07.1` and `:develop`.