### PR TITLE
Guard against empty column list in return_noisy_stats (#94)

### DIFF
--- a/aidrin/headless/runners.py
+++ b/aidrin/headless/runners.py
@@ -340,6 +340,17 @@ def _dp_error_payload(error_message: str) -> Dict[str, Any]:
             "Variance of feature (after noise)": "N/A",
             "Noisy file saved": "Failed - No data to process",
         }
+    if "No columns selected" in error_message:
+        return {
+            "Error": "No numerical features selected for differential privacy.",
+            "DP Statistics Visualization": "",
+            "Graph interpretation": "No visualization available due to invalid parameters.",
+            "Mean of feature (before noise)": "N/A",
+            "Variance of feature (before noise)": "N/A",
+            "Mean of feature (after noise)": "N/A",
+            "Variance of feature (after noise)": "N/A",
+            "Noisy file saved": "Failed - Invalid parameters",
+        }
     return {
         "Error": f"Processing error: {error_message}",
         "DP Statistics Visualization": "",

--- a/aidrin/structured_data_metrics/add_noise.py
+++ b/aidrin/structured_data_metrics/add_noise.py
@@ -24,6 +24,9 @@ def return_noisy_stats(add_noise_columns, epsilon, file_info):
     if epsilon <= 0:
         raise Exception("Epsilon must be greater than 0")
 
+    if not add_noise_columns:
+        raise Exception("No columns selected for noise addition")
+
     if isinstance(file_info, str):
         df = pd.read_json(file_info)
     else:

--- a/tests/unit/test_add_noise.py
+++ b/tests/unit/test_add_noise.py
@@ -1,0 +1,77 @@
+"""Unit tests for the differential privacy metric (add_noise.py).
+
+These tests run without Flask, Celery, or Redis.  return_noisy_stats is a
+plain Python function so it is called directly with DataFrames.
+"""
+
+import sys
+import types
+import unittest
+
+import matplotlib
+import pandas as pd
+
+matplotlib.use("Agg")
+
+# ---------------------------------------------------------------------------
+# Stubs — must be installed before any aidrin import
+# ---------------------------------------------------------------------------
+
+if "pkg_resources" not in sys.modules:
+    _pkg = types.ModuleType("pkg_resources")
+
+    class _FakeDist:
+        version = "0.0.0"
+
+    _pkg.get_distribution = lambda _name: _FakeDist()
+    sys.modules["pkg_resources"] = _pkg
+
+# ---------------------------------------------------------------------------
+# Imports under test
+# ---------------------------------------------------------------------------
+
+from aidrin.structured_data_metrics.add_noise import (  # noqa: E402
+    return_noisy_stats,
+)
+
+
+class TestReturnNoisyStats(unittest.TestCase):
+
+    def setUp(self):
+        self.df = pd.DataFrame({
+            "age": [25, 30, 35],
+            "salary": [50000, 60000, 70000],
+        })
+
+    def test_no_columns_selected(self):
+        with self.assertRaises(Exception) as ctx:
+            return_noisy_stats([], 0.5, self.df)
+        self.assertIn("No columns selected", str(ctx.exception))
+
+    def test_single_column(self):
+        result = return_noisy_stats(["age"], 0.5, self.df)
+        self.assertIn("Mean of feature age(before noise)", result)
+        self.assertIn("DP Statistics Visualization", result)
+
+    def test_invalid_epsilon(self):
+        with self.assertRaises(Exception) as ctx:
+            return_noisy_stats(["age"], 0, self.df)
+        self.assertIn("Epsilon must be greater than 0", str(ctx.exception))
+
+
+class TestDpErrorPayload(unittest.TestCase):
+    """The headless runner turns the raised message into a user-facing payload."""
+
+    def test_no_columns_message_is_mapped(self):
+        from aidrin.headless.runners import _dp_error_payload
+
+        payload = _dp_error_payload("No columns selected for noise addition")
+        self.assertEqual(
+            payload["Error"],
+            "No numerical features selected for differential privacy.",
+        )
+        self.assertEqual(payload["Noisy file saved"], "Failed - Invalid parameters")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #94.

## Problem

`return_noisy_stats()` computes its subplot grid from `len(add_noise_columns)`. With an empty list that becomes `plt.subplots(0, 0)`, which raises:

```
ValueError: Number of rows must be a positive integer, not 0
```

Reproduced on current `develop`:

```python
from aidrin.structured_data_metrics.add_noise import return_noisy_stats
import pandas as pd

df = pd.DataFrame({"age": [25, 30, 35], "salary": [50000, 60000, 70000]})
return_noisy_stats([], 0.5, df)   # ValueError
```

## Change

- `add_noise.py`: reject an empty column list up front, next to the existing `epsilon` and empty-dataset guards.
- `headless/runners.py`: map the new message onto the same DP error payload shape the other two guarded messages already use, so CLI/MCP callers get "No numerical features selected for differential privacy." instead of the generic "Processing error: …" fallback.
- `tests/unit/test_add_noise.py`: new test module covering the empty list, a valid single column, invalid epsilon, and the headless payload mapping.

## A note on the approach

The issue proposed `raise Exception(...)`, and @Aman-Cool suggested an early `return {"Error": ...}` instead, out of concern the exception would surface as a bare task failure. I went with raising, because:

- `return_noisy_stats` is a plain function, not a Celery task so nothing swallows the exception.
- Both callers (`web/routes/metrics.py:_process_differential_privacy` and `headless/runners.py:run_differential_privacy`) already wrap the call in `try/except` and translate the message into a full DP error payload. Raising is the convention this function already follows for its other two invalid-input cases.
- Returning a bare `{"Error": ...}` would skip that translation and omit the payload keys (`DP Statistics Visualization`, `Mean of feature (before noise)`, …) the UI expects.

Note: the web UI already blocks an empty feature list before reaching this function, so the crash was only reachable through the CLI/MCP and direct API use.