### PR TITLE
Remove unused percentage calculation from compare_rep_rates (#95)

### DIFF
--- a/aidrin/structured_data_metrics/compare_representation_rate.py
+++ b/aidrin/structured_data_metrics/compare_representation_rate.py
@@ -42,30 +42,17 @@ def compare_rep_rates(self: Task, rep_dict, rrr_dict):
             real_values.append(value2)
             dataset_values.append(value1)
 
-        # Calculate the total for each category
-        totals = [v1 + v2 for v1, v2 in zip(real_values, dataset_values)]
-
-        # Calculate the percentages for each stack
-        percentages1 = [(v1 / total) * 100 for v1, total in zip(real_values, totals)]
-        percentages2 = [(v2 / total) * 100 for v2, total in zip(dataset_values, totals)]
-
         fig, ax = plt.subplots(figsize=(8, 8))
         plt.subplots_adjust(left=0.2)
 
         # Create an array for the y-axis positions
         y = np.arange(len(categories))
 
-        # Plot the first stacked bars and annotate with percentages
-        bars1 = ax.barh(y, real_values, label="Real World", color="blue")
-        for i, bar, percentage in zip(y, bars1, percentages1):
-            bar.get_width()
+        # Plot the first stacked bars
+        ax.barh(y, real_values, label="Real World", color="blue")
 
-        # Plot the second stacked bars on top of the first ones and annotate with percentages
-        bars2 = ax.barh(
-            y, dataset_values, label="Dataset", color="red", left=real_values
-        )
-        for i, bar, percentage in zip(y, bars2, percentages2):
-            bar.get_width()
+        # Plot the second stacked bars on top of the first ones
+        ax.barh(y, dataset_values, label="Dataset", color="red", left=real_values)
 
         # Customize the y-axis labels
         ax.set_yticks(y)

--- a/tests/unit/test_compare_representation_rate.py
+++ b/tests/unit/test_compare_representation_rate.py
@@ -1,0 +1,98 @@
+"""Unit tests for compare_rep_rates (compare_representation_rate.py).
+
+These tests run without Flask, Celery, or Redis.  The Celery task is invoked
+via .apply() after configuring a minimal always-eager Celery app so the task
+decorator is satisfied without a running broker.
+"""
+
+import sys
+import types
+import unittest
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+# ---------------------------------------------------------------------------
+# Stubs — must be installed before any aidrin import
+# ---------------------------------------------------------------------------
+
+if "pkg_resources" not in sys.modules:
+    _pkg = types.ModuleType("pkg_resources")
+
+    class _FakeDist:
+        version = "0.0.0"
+
+    _pkg.get_distribution = lambda _name: _FakeDist()
+    sys.modules["pkg_resources"] = _pkg
+
+# ---------------------------------------------------------------------------
+# Minimal always-eager Celery app so shared_task decorators resolve cleanly
+# ---------------------------------------------------------------------------
+
+from celery import Celery  # noqa: E402
+
+_celery_app = Celery("tests")
+_celery_app.conf.update(task_always_eager=True, task_eager_propagates=True)
+_celery_app.set_default()
+
+# ---------------------------------------------------------------------------
+# Imports under test
+# ---------------------------------------------------------------------------
+
+from aidrin.structured_data_metrics.compare_representation_rate import (  # noqa: E402
+    compare_rep_rates,
+)
+
+
+def _key(column, value_from, value_to):
+    """Build a key in the format calculate_representation_rate emits."""
+    return (
+        f"Column: '{column}', Probability ratio for "
+        f"'{value_from}' to '{value_to}'"
+    )
+
+
+class TestCompareRepRates(unittest.TestCase):
+
+    def test_both_rates_zero(self):
+        """Both rates zero makes the total zero; must not raise ZeroDivisionError."""
+        key = _key("race", "A", "B")
+        result = compare_rep_rates.apply(args=({key: 0.0}, {key: 0.0})).get()
+
+        comparisons = result["Comparisons"]
+        self.assertAlmostEqual(
+            comparisons["Real vs Dataset Representation rate difference in 'A' to 'B'"],
+            0.0,
+        )
+        self.assertIn("Comparison Visualization", comparisons)
+
+    def test_mixed_zero_and_nonzero_totals(self):
+        """A zero-total pair must not stop other pairs from being compared."""
+        zero_key = _key("race", "A", "B")
+        other_key = _key("sex", "M", "F")
+        rep = {zero_key: 0.0, other_key: 1.0}
+        rrr = {zero_key: 0.0, other_key: 2.0}
+
+        comparisons = compare_rep_rates.apply(args=(rep, rrr)).get()["Comparisons"]
+        self.assertAlmostEqual(
+            comparisons["Real vs Dataset Representation rate difference in 'M' to 'F'"],
+            1.0,
+        )
+
+    def test_nonzero_rates(self):
+        """The ordinary path still reports the absolute difference."""
+        key = _key("race", "A", "B")
+        comparisons = compare_rep_rates.apply(
+            args=({key: 0.5}, {key: 2.0})
+        ).get()["Comparisons"]
+
+        self.assertAlmostEqual(
+            comparisons["Real vs Dataset Representation rate difference in 'A' to 'B'"],
+            1.5,
+        )
+        self.assertIn("Comparison Visualization", comparisons)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #95.

## Problem

When a representation rate is `0` in both the real-world and dataset dicts for the same key, the category total is `0` and the percentage calculation divides by zero. Reproduced on current `develop`, using the key format `calculate_representation_rate` actually emits:

```python
key = "Column: 'race', Probability ratio for 'A' to 'B'"
compare_rep_rates.apply(args=({key: 0.0}, {key: 0.0})).get()
# ZeroDivisionError: float division by zero
```

## Change

The issue proposed guarding the division with `if total != 0 else 0`. While writing the test I found the values being guarded are never used:

```python
percentages1 = [(v1 / total) * 100 for v1, total in zip(real_values, totals)]
...
bars1 = ax.barh(y, real_values, label="Real World", color="blue")
for i, bar, percentage in zip(y, bars1, percentages1):
    bar.get_width()          # <- result discarded; percentage never read
```

Both loops annotate nothing: the body is a bare `bar.get_width()` whose return value is thrown away, and `percentage` is never referenced. The same is true for `percentages2`. `totals` exists only to feed those two lists.

So rather than guarding a division whose result nobody consumes, this PR deletes `totals`, `percentages1`, `percentages2` and the two no-op loops. The crash disappears because the offending arithmetic is gone, and the plot is untouched — the `ax.barh(...)` calls that actually draw the bars remain (they no longer need to be bound to `bars1`/`bars2`, since nothing read those either).

If the intent was to eventually label each bar with its percentage, that annotation was never implemented; it would be worth doing as a separate feature, on top of a `total != 0` guard.