### PR TITLE
Confine web-supplied dataset paths to the upload folder

### DIFF
--- a/tests/unit/test_path_confinement.py
+++ b/tests/unit/test_path_confinement.py
@@ -1,0 +1,56 @@
+"""Tests for the upload-folder path-traversal barrier.
+
+Web-supplied dataset paths (from the Flask session) flow into ``file_parser``'s
+filesystem calls. ``confine_to_upload_folder`` is the barrier that keeps those
+paths inside ``UPLOAD_FOLDER`` (CWE-22 / CodeQL ``py/path-injection``).
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from flask import Flask
+
+from web.routes.utils import build_file_info, confine_to_upload_folder
+
+
+class ConfineToUploadFolderTests(unittest.TestCase):
+    def setUp(self):
+        self.upload_dir = tempfile.mkdtemp()
+        self.app = Flask(__name__)
+        self.app.config["UPLOAD_FOLDER"] = self.upload_dir
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
+        shutil.rmtree(self.upload_dir, ignore_errors=True)
+
+    def test_accepts_path_inside_upload_folder(self):
+        inside = os.path.join(self.upload_dir, "abc123_data.csv")
+        self.assertEqual(confine_to_upload_folder(inside), os.path.realpath(inside))
+
+    def test_rejects_parent_traversal(self):
+        escape = os.path.join(self.upload_dir, "..", "..", "etc", "passwd")
+        self.assertEqual(confine_to_upload_folder(escape), "")
+
+    def test_rejects_absolute_outside_path(self):
+        self.assertEqual(confine_to_upload_folder("/etc/passwd"), "")
+
+    def test_missing_path_returns_empty(self):
+        self.assertEqual(confine_to_upload_folder(""), "")
+        self.assertEqual(confine_to_upload_folder(None), "")
+
+    def test_build_file_info_nulls_out_escaping_path(self):
+        info = build_file_info("/etc/passwd", "passwd", ".csv")
+        self.assertEqual(info[0], "")
+
+    def test_build_file_info_keeps_valid_path(self):
+        inside = os.path.join(self.upload_dir, "abc123_data.csv")
+        info = build_file_info(inside, "data.csv", ".csv")
+        self.assertEqual(info[0], os.path.realpath(inside))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -20,6 +20,7 @@ from aidrin.file_handling.file_parser import SUPPORTED_FILE_TYPES, READER_MAP
 from aidrin.file_handling.readers.hdf5_reader import hdf5Reader
 from web.routes.utils import (
     clear_all_user_cache,
+    confine_to_upload_folder,
     ensure_json_serializable,
     get_current_user_id,
     load_dataframe,
@@ -52,6 +53,13 @@ def inspector():
             display_name = file.filename
             filename = f"{uuid.uuid4().hex}_{secure_filename(file.filename)}"
             file_path = os.path.join(current_app.config["UPLOAD_FOLDER"], filename)
+            # Defense in depth: confirm the destination stays inside the upload
+            # folder before writing, so a bypass of secure_filename can never
+            # steer the write to an arbitrary location.
+            file_path = confine_to_upload_folder(file_path)
+            if not file_path:
+                file_upload_time_log.error("Rejected unsafe upload path: %s", filename)
+                return redirect(url_for("core.inspector"))
             file.save(file_path)
 
             session["uploaded_file_name"] = display_name
@@ -246,7 +254,7 @@ def filter_file():
         else:
             keys_list = [str(keys)]
 
-        file_path = session.get("uploaded_file_path")
+        file_path = confine_to_upload_folder(session.get("uploaded_file_path"))
         file_type = session.get("uploaded_file_type")
         if file_path and file_type == ".h5" and len(keys_list) > 1:
             inv = hdf5Reader(file_path, file_upload_time_log).inventory()
@@ -416,7 +424,7 @@ def summary_statistics():
             return jsonify({"success": False, "message": "An internal error occurred"})
 
     try:
-        file_path = session.get("uploaded_file_path")
+        file_path = confine_to_upload_folder(session.get("uploaded_file_path"))
         file_name = session.get("uploaded_file_name")
         file_type = session.get("uploaded_file_type")
 
@@ -531,7 +539,7 @@ def summary_statistics():
 @core_bp.route("/feature-set", methods=["POST"])
 def extract_features():
     try:
-        file_path = session.get("uploaded_file_path")
+        file_path = confine_to_upload_folder(session.get("uploaded_file_path"))
         file_name = session.get("uploaded_file_name")
         file_type = session.get("uploaded_file_type")
 

--- a/web/routes/custom.py
+++ b/web/routes/custom.py
@@ -19,7 +19,12 @@ from flask import (
     url_for,
 )
 from aidrin.file_handling.file_parser import read_file
-from web.routes.utils import ensure_json_serializable, store_result, get_result_or_default
+from web.routes.utils import (
+    confine_to_upload_folder,
+    ensure_json_serializable,
+    store_result,
+    get_result_or_default,
+)
 
 custom_bp = Blueprint("custom", __name__)
 
@@ -68,7 +73,7 @@ class CustomDR(BaseDRAgent):
 @custom_bp.route("/custom-metrics", methods=["GET", "POST"])
 def custom_metrics():
     final_dict = {}
-    data_file_path = session.get("uploaded_file_path")
+    data_file_path = confine_to_upload_folder(session.get("uploaded_file_path"))
     data_file_name = session.get("uploaded_file_name")
     data_file_type = session.get("uploaded_file_type")
     file_info = (data_file_path, data_file_name, data_file_type)

--- a/web/routes/metrics.py
+++ b/web/routes/metrics.py
@@ -54,6 +54,7 @@ from aidrin.structured_data_metrics.representation_rate import (
 from aidrin.structured_data_metrics.statistical_rate import calculate_statistical_rates
 from web.routes.utils import (
     build_file_info,
+    confine_to_upload_folder,
     ensure_json_serializable,
     format_dict_values,
     generate_metric_cache_key,
@@ -74,7 +75,7 @@ METRIC_CELERY_TIMEOUT = 120
 
 @metrics_bp.route("/custom-outlier-targets", methods=["GET", "POST"])
 def custom_outlier_targets():
-    file_path = session.get("uploaded_file_path")
+    file_path = confine_to_upload_folder(session.get("uploaded_file_path"))
     file_name = session.get("uploaded_file_name")
     file_type = session.get("uploaded_file_type")
     if not file_path:

--- a/web/routes/utils.py
+++ b/web/routes/utils.py
@@ -3,6 +3,7 @@
 import io
 import base64
 import logging
+import os
 import time
 import uuid
 
@@ -17,6 +18,38 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Path confinement
+# ---------------------------------------------------------------------------
+
+def confine_to_upload_folder(file_path):
+    """Return ``file_path`` resolved, iff it lives inside ``UPLOAD_FOLDER``.
+
+    Dataset paths supplied over the web (via the Flask session) flow into
+    ``file_parser``'s ``os.stat``/``os.path.exists``/``tempfile``/``os.replace``
+    calls. This is the path-traversal barrier (CWE-22) for those values: the
+    path is canonicalised with ``os.path.realpath`` and rejected unless it stays
+    within the configured upload directory, so a forged/tampered session cookie
+    cannot steer file operations at arbitrary locations on disk.
+
+    Returns the canonical path on success, or ``""`` for a missing or
+    out-of-bounds path (callers treat an empty path as "no file").
+    """
+    if not file_path:
+        return ""
+    base = os.path.realpath(current_app.config["UPLOAD_FOLDER"])
+    resolved = os.path.realpath(file_path)
+    try:
+        contained = resolved == base or os.path.commonpath([resolved, base]) == base
+    except ValueError:
+        # Different drives / mixed path kinds — not inside the upload folder.
+        contained = False
+    if not contained:
+        logger.warning("Rejected dataset path outside upload folder: %s", file_path)
+        return ""
+    return resolved
+
+
+# ---------------------------------------------------------------------------
 # File loading
 # ---------------------------------------------------------------------------
 
@@ -25,7 +58,11 @@ def build_file_info(file_path, file_name, file_type, selected_keys=None):
 
     Celery workers do not have Flask session context, so multi-dataset HDF5
     files must carry ``selected_keys`` in the tuple for background tasks.
+
+    The path is confined to the upload folder here so every ``read_file`` fed
+    from a session value passes through the path-traversal barrier.
     """
+    file_path = confine_to_upload_folder(file_path)
     if file_type == ".h5":
         if selected_keys is None:
             try:


### PR DESCRIPTION
## What

Fixes the eight open **CodeQL `py/path-injection` (CWE-22)** code-scanning alerts (#63–#70), all in `aidrin/file_handling/file_parser.py`.

## Root cause

The uploaded dataset path flows from `request.files` → Flask session (`uploaded_file_path`) → `read_file`, where it reaches `os.stat`, `os.path.exists`, `tempfile.mkstemp(dir=...)`, `os.replace`, and `os.remove` with no barrier CodeQL recognises. The upload handler already sanitizes the *filename* (`secure_filename` + uuid), but CodeQL tracks the tainted value into the filesystem sinks and there is no containment check.

`file_parser` is shared with the **headless CLI**, which legitimately reads arbitrary local paths — so the fix cannot live in `file_parser`. It belongs at the **web boundary**, where `UPLOAD_FOLDER` is the known-safe root.

## Change

- Add `confine_to_upload_folder()` in `web/routes/utils.py`: canonicalises the path with `os.path.realpath` and rejects anything resolving outside `UPLOAD_FOLDER` (returns `""`, which callers already treat as "no file"). This is the sanitizer pattern CodeQL recognises for path injection.
- Apply it on every web flow where a session path becomes a `file_info` for `read_file`:
  - inside `build_file_info` (covers the 7 metrics routes),
  - the direct-tuple sites in `custom.py`, `core.py` (×2), and `metrics.py` (`iter_targets`),
  - the `.h5` `filter_file` route.
- Harden the upload handler itself (defense in depth): confirm the write destination is inside `UPLOAD_FOLDER` before saving.

Headless/CLI paths are untouched — they never pass through the web helper.

## Testing

- New `tests/unit/test_path_confinement.py` (6 tests): accepts in-folder paths, rejects `../` traversal and absolute outside paths, and verifies `build_file_info` nulls out escaping paths. All pass.
- `flake8` clean; edited modules import cleanly; existing unit suite unaffected (the pre-existing `FrameCache`/`test_privacy` failures reproduce on `develop` and are due to a missing `pyarrow`/environment, not this change).

Final confirmation will come from GitHub's CodeQL re-scan on this PR.