### PR TITLE
summary stats caching and cleanup CLI frame-cache

### DIFF
--- a/aidrin/file_handling/file_parser.py
+++ b/aidrin/file_handling/file_parser.py
@@ -71,6 +71,29 @@ def _frame_cache_path(file_path):
     return f"{file_path}.{st.st_size}-{st.st_mtime_ns}{_FRAME_CACHE_SUFFIX}"
 
 
+def clear_frame_cache(file_path):
+    """Best-effort removal of the on-disk Feather cache sidecar for ``file_path``.
+
+    The web app reaps its cache sidecars via the ``UPLOAD_FOLDER`` prune task
+    (see ``worker.tasks.prune_upload_folder``), but CLI invocations read files
+    from arbitrary, unmanaged locations on disk with nothing to sweep them
+    later. Callers that own a single, short-lived invocation (e.g. the CLI's
+    ``main()``) should call this once after the run so the sidecar doesn't
+    linger next to the source file. Safe to call even when no cache was
+    written (unsupported type, disabled cache, or write failure).
+    """
+    if not file_path or not os.path.exists(file_path):
+        return
+    try:
+        cache_path = _frame_cache_path(file_path)
+    except OSError:
+        return
+    try:
+        os.remove(cache_path)
+    except OSError:
+        pass
+
+
 def _write_frame_cache(cache_path, df):
     """Best-effort atomic Feather write of ``df`` to ``cache_path``.
 

--- a/aidrin/headless/cli.py
+++ b/aidrin/headless/cli.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import List, Optional
 import os
 
+from aidrin.file_handling.file_parser import clear_frame_cache
+
 from .api import (
     METRIC_REGISTRY,
     list_available_metrics,
@@ -552,6 +554,13 @@ def main() -> None:
             argv = ["run", metric_key.replace("_", "-")] + argv[1:]
     args = parser.parse_args(argv)
 
+    # Cache sidecar cleanup: unlike the web app (whose uploads live in a
+    # managed, periodically-reaped folder), the CLI reads files from
+    # arbitrary locations on disk, so nothing else will clean up the
+    # ``.aidrin.feather`` cache written by read_file(). Track the dataset
+    # path(s) touched by this invocation and sweep them in `finally` below.
+    cleanup_path = getattr(args, "file_path", None)
+
     try:
         if args.command == "add-custom-module":
             target_dir = args.custom_dir or os.getcwd()
@@ -634,6 +643,7 @@ def main() -> None:
 
         if args.command == "batch":
             config = HeadlessConfig.from_file(args.config_path)
+            cleanup_path = config.file_path
             result = run_batch_metrics(
                 config,
                 verbose=args.verbose,
@@ -676,6 +686,9 @@ def main() -> None:
     except Exception as exc:
         sys.stderr.write(f"Error: {exc}\n")
         sys.exit(1)
+    finally:
+        if cleanup_path:
+            clear_frame_cache(cleanup_path)
 
 
 if __name__ == "__main__":

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from web import create_app
 
 
 @pytest.fixture
-def app():
+def app(tmp_path):
     """Create a new Flask app instance for testing."""
     app = create_app()
     app.config.update(TESTING=True)
@@ -17,6 +17,21 @@ def app():
     # Run Celery tasks eagerly (synchronously) so no Redis is required
     app.config["CELERY"]["task_always_eager"] = True
     app.config["CELERY"]["task_eager_propagates"] = True
+
+    # Routes read these paths from current_app.config at request time, so
+    # redirecting them here keeps tests from writing real files into the
+    # live project folders (aidrin/custom_metrics/, data/uploads/).
+    upload_folder = tmp_path / "uploads"
+    upload_folder.mkdir()
+    app.config["UPLOAD_FOLDER"] = str(upload_folder)
+
+    custom_metrics_folder = tmp_path / "custom_metrics"
+    custom_metrics_folder.mkdir()
+    app.config["CUSTOM_METRICS_FOLDER"] = str(custom_metrics_folder)
+
+    remedy_folder = custom_metrics_folder / "remedy_data"
+    remedy_folder.mkdir()
+    app.config["REMEDY_FOLDER"] = str(remedy_folder)
 
     return app
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,5 @@
 """Shared fixtures for integration tests."""
 
-import io
-import os
-import tempfile
-
 import pytest
 from web import create_app
 

--- a/tests/integration/test_summary_statistics.py
+++ b/tests/integration/test_summary_statistics.py
@@ -6,6 +6,10 @@ object-column stats and the numeric formatter raised
 ``TypeError: bad operand type for abs(): 'str'``.
 """
 
+from unittest.mock import patch
+
+import web.routes.core as core
+
 
 def _upload(client, tmp_path, content, name="all_strings.csv", ftype=".csv"):
     path = tmp_path / name
@@ -59,3 +63,45 @@ def test_summary_statistics_mixed_still_works(client, tmp_path):
     assert sorted(data["numerical_features"]) == ["age", "score"]
     assert "age" in data["summary_statistics"]
     assert data["categorical_features"] == ["name"]
+
+
+def test_summary_statistics_second_request_is_cached(client, tmp_path):
+    """A repeat GET for the same file must reuse the cached result, not recompute."""
+    _upload(
+        client,
+        tmp_path,
+        "name,age,score\nAlice,25,90.5\nBob,30,85.0\n",
+        name="mixed.csv",
+    )
+
+    with patch.object(core, "summary_histograms", wraps=core.summary_histograms) as spy:
+        first = client.get("/summary-statistics")
+        second = client.get("/summary-statistics")
+        assert spy.call_count == 1
+
+    assert first.status_code == second.status_code == 200
+    assert first.get_json() == second.get_json()
+
+
+def test_summary_statistics_different_file_not_cached(client, tmp_path):
+    """Switching to a different uploaded file must not return the prior file's cache."""
+    _upload(
+        client,
+        tmp_path,
+        "name,age,score\nAlice,25,90.5\nBob,30,85.0\n",
+        name="mixed.csv",
+    )
+    first = client.get("/summary-statistics").get_json()
+
+    _upload(
+        client,
+        tmp_path,
+        "name,department,level\nAlice,Engineering,Senior\nBob,Sales,Junior\n",
+        name="all_strings.csv",
+    )
+    second = client.get("/summary-statistics").get_json()
+
+    assert first["records_count"] == second["records_count"] == 2
+    assert second["numerical_features"] == []
+    assert second["summary_statistics"] == {}
+    assert sorted(second["categorical_features"]) == ["department", "level", "name"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -458,6 +458,44 @@ class TestAddCustomModuleCommand(unittest.TestCase):
 
 
 # ===========================================================================
+# Frame cache cleanup
+# ===========================================================================
+
+
+def _frame_cache_siblings(path: str) -> list[str]:
+    directory = os.path.dirname(path) or "."
+    prefix = os.path.basename(path)
+    return [f for f in os.listdir(directory) if f.startswith(prefix) and f.endswith(".aidrin.feather")]
+
+
+class TestFrameCacheCleanup(unittest.TestCase):
+    """The CLI reads files from arbitrary disk locations with no periodic
+    reaper (unlike the web app's managed upload folder), so it must remove
+    its own ``.aidrin.feather`` cache sidecar after each invocation."""
+
+    def setUp(self):
+        self.csv = _write_csv(_sample_df())
+
+    def tearDown(self):
+        for name in _frame_cache_siblings(self.csv):
+            _clean(os.path.join(os.path.dirname(self.csv) or ".", name))
+        _clean(self.csv)
+
+    def test_no_cache_sidecar_left_after_run_command(self):
+        _run_cli("run", "completeness", self.csv)
+        self.assertEqual(_frame_cache_siblings(self.csv), [])
+
+    def test_no_cache_sidecar_left_after_data_quality_command(self):
+        _run_cli("data-quality", self.csv)
+        self.assertEqual(_frame_cache_siblings(self.csv), [])
+
+    def test_no_cache_sidecar_left_after_failed_run(self):
+        # Nonexistent target column still exercises read_file() before failing.
+        _run_cli("run", "class-imbalance", self.csv, "not_a_real_column")
+        self.assertEqual(_frame_cache_siblings(self.csv), [])
+
+
+# ===========================================================================
 # Error handling
 # ===========================================================================
 

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 import uuid
 
 import pandas as pd
@@ -22,7 +23,9 @@ from web.routes.utils import (
     clear_all_user_cache,
     confine_to_upload_folder,
     ensure_json_serializable,
+    generate_metric_cache_key,
     get_current_user_id,
+    is_metric_cache_valid,
     load_dataframe,
     summary_histograms,
 )
@@ -433,27 +436,41 @@ def summary_statistics():
         if not file_type:
             return jsonify({"success": False, "message": "File type not set in session"}), 200
 
+        selected = []
+        if file_type == ".h5":
+            selected = session.get("selected_keys") or []
+            if isinstance(selected, str):
+                selected = [key.strip() for key in selected.split(",") if key.strip()]
+
+        cache_key = generate_metric_cache_key(file_name, "summarystats", selected_keys=selected)
+        cached_entry = current_app.TEMP_RESULTS_CACHE.get(cache_key)
+        if cached_entry and is_metric_cache_valid(cached_entry):
+            current_app.TEMP_RESULTS_CACHE[cache_key] = {
+                "data": cached_entry["data"],
+                "timestamp": time.time(),
+                "expires_at": time.time() + (30 * 60),
+            }
+            return jsonify(cached_entry["data"])
+        if cached_entry:
+            current_app.TEMP_RESULTS_CACHE.pop(cache_key, None)
+
         if file_type == ".h5":
             inv = hdf5Reader(file_path, file_upload_time_log).inventory()
-            if inv["type"] == "multi_dataset":
-                selected = session.get("selected_keys") or []
-                if isinstance(selected, str):
-                    selected = [key.strip() for key in selected.split(",") if key.strip()]
-                if not selected:
-                    return jsonify(
-                        ensure_json_serializable({
-                            "success": False,
-                            "needs_dataset_selection": True,
-                            "datasets": inv["datasets"],
-                            "groups": inv.get("groups", []),
-                            "current_checked_keys": selected,
-                            "message": (
-                                "This HDF5 file contains multiple datasets with "
-                                "different shapes. Select one or more compatible "
-                                "datasets (same length) to analyze."
-                            ),
-                        })
-                    ), 200
+            if inv["type"] == "multi_dataset" and not selected:
+                return jsonify(
+                    ensure_json_serializable({
+                        "success": False,
+                        "needs_dataset_selection": True,
+                        "datasets": inv["datasets"],
+                        "groups": inv.get("groups", []),
+                        "current_checked_keys": selected,
+                        "message": (
+                            "This HDF5 file contains multiple datasets with "
+                            "different shapes. Select one or more compatible "
+                            "datasets (same length) to analyze."
+                        ),
+                    })
+                ), 200
 
         file_info = (file_path, file_name, file_type)
         df, load_error = load_dataframe(file_info)
@@ -493,15 +510,8 @@ def summary_statistics():
                     new_key = old_key.replace("%", "th percentile")
                     v[new_key] = v.pop(old_key)
 
-        hdf5_multi_dataset = False
-        selected_dataset_keys = []
-        if file_type == ".h5":
-            selected = session.get("selected_keys") or []
-            if isinstance(selected, str):
-                selected = [key.strip() for key in selected.split(",") if key.strip()]
-            if selected:
-                hdf5_multi_dataset = True
-                selected_dataset_keys = selected
+        hdf5_multi_dataset = bool(selected)
+        selected_dataset_keys = selected
 
         categorical_summary = {}
         for col in categorical_columns:
@@ -530,6 +540,11 @@ def summary_statistics():
             "hdf5_multi_dataset": hdf5_multi_dataset,
             "selected_dataset_keys": selected_dataset_keys,
         })
+        current_app.TEMP_RESULTS_CACHE[cache_key] = {
+            "data": response_data,
+            "timestamp": time.time(),
+            "expires_at": time.time() + (30 * 60),
+        }
         return jsonify(response_data)
     except Exception as e:
         file_upload_time_log.error("Error computing summary statistics: %s", e, exc_info=True)

--- a/web/routes/utils.py
+++ b/web/routes/utils.py
@@ -180,6 +180,10 @@ def generate_metric_cache_key(file_name, metric_type, **params):
         dist_metric = params.get("dist_metric", "EU")
         cache_parts.append(f"classimbalance:classes:{classes}:dist_metric:{dist_metric}")
 
+    elif metric_type == "summarystats":
+        selected_keys = params.get("selected_keys", [])
+        cache_parts.append(f"summarystats:keys:{', '.join(sorted(selected_keys))}")
+
     return "|".join(cache_parts)
 
 


### PR DESCRIPTION
# Related Issues / Pull Requests

None

# Description

Three changes on this branch:

- Caches summary statistics results in the web app (like other metrics already do), 
- Fixes the CLI leaving stray `.aidrin.feather` cache files next to datasets after each run, 
- Isolates integration tests so they stop writing real files into `aidrin/custom_metrics/` and `data/uploads/`.


# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [X] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
