### PR TITLE
Fix false-positive path-injection alerts from Celery task arg mapping

### DIFF
--- a/web/routes/metrics.py
+++ b/web/routes/metrics.py
@@ -21,7 +21,7 @@ from aidrin.structured_data_metrics.class_imbalance import (
     class_distribution_plot,
 )
 from aidrin.structured_data_metrics.completeness import completeness
-from aidrin.structured_data_metrics.custom_outliers import custom_outliers
+from aidrin.structured_data_metrics.custom_outliers import calculate_custom_outliers
 from aidrin.structured_data_metrics.conditional_demo_disp import (
     conditional_demographic_disparity,
 )
@@ -158,7 +158,14 @@ def data_quality():
                         max_export_rows = request.form.get("max_export_rows", 10000)
                         try:
                             with tracer.start_as_current_span("metric.custom_outliers"):
-                                custom_dict = custom_outliers(
+                                # Call the plain function, not the @shared_task
+                                # wrapper: invoking the bound task synchronously
+                                # confuses CodeQL's argument mapping (it aligns
+                                # ``rules`` with the ``file_info`` parameter
+                                # because it can't see Celery's injected
+                                # ``self``), yielding false-positive
+                                # py/path-injection alerts in file_parser.
+                                custom_dict = calculate_custom_outliers(
                                     file_info,
                                     rules,
                                     max_outliers,


### PR DESCRIPTION
## Why the alerts were still open after #157

#157 confined the uploaded dataset path to `UPLOAD_FOLDER`, but the eight CodeQL `py/path-injection` alerts in `aidrin/file_handling/file_parser.py` persisted after the merge (re-scanned on `develop` @ `e71cda0`). I pulled the SARIF code-flow: **CodeQL's tracked taint never touches the session path.** All 27 flows into those sinks start at `request.form` and run:

```
request.form["custom_outlier_rules"]  (metrics.py)
  → rules
  → custom_outliers(file_info, rules, ...)        # @shared_task(bind=True)
  → file_info parameter                            # <-- mis-mapped
  → read_file → os.stat / os.path.exists / tempfile / os.replace
```

## Root cause: not a real injection

`custom_outliers` is a Celery task decorated with `@shared_task(bind=True)`, so its signature is `def custom_outliers(self, file_info, rules, ...)`. The data-quality route invoked it **synchronously** as `custom_outliers(file_info, rules, ...)`. CodeQL can't see Celery's injected `self`, so it aligns arguments one slot to the left and concludes the tainted `rules` argument lands in the `file_info` parameter — then follows `rules` into the file-path calls. `rules` is never used as a path at runtime; this is a false positive driven purely by the decorator.

That also explains why session-path confinement didn't help: the real `file_info` argument gets mapped to `self` and dropped, so CodeQL wasn't tracking it at all.

## Fix

Call the plain, undecorated `calculate_custom_outliers(file_info, rules, ...)` — which the task itself just delegates to — from the route. Argument positions now line up, `rules` no longer masquerades as `file_info`, and the false-positive flow disappears. The `@shared_task` wrapper is untouched and still used for Celery dispatch (`aidrin/__init__.py`, headless runners). Behaviour is identical, since the route already executed the task synchronously.

## Verification

- SARIF analysis: all 27 tracked flows into the `file_parser` sinks pass through this call site — no bypassing flow remains.
- `tests/unit/test_data_quality.py` + `tests/unit/test_custom_outliers.py`: 50 passed.
- flake8 clean.
- Definitive confirmation will come from GitHub's CodeQL re-scan once merged to `develop`.

Note: #157's path confinement is left in place as legitimate defense-in-depth.