### PR TITLE
Add data-structure metrics: max pairwise correlation, skewness, kurtosis

### DIFF
--- a/.claude/skills/aidrin/SKILL.md
+++ b/.claude/skills/aidrin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aidrin
-description: Use when the user asks "is my data AI ready", "is my dataset ready", "what is the quality of my data", whether data is good enough to train or publish, to check a dataset for bias, fairness, privacy, PII risk, HIPAA compliance, protected health information, PHI, class imbalance, duplicates, outliers, completeness, feature relevance, k-anonymity, or mentions AIDRIN. Supports CSV, Excel (.xls/.xlsb/.xlsx/.xlsm), JSON, NumPy (.npz), HDF5 (.h5), and Parquet files.
+description: Use when the user asks "is my data AI ready", "is my dataset ready", "what is the quality of my data", whether data is good enough to train or publish, to check a dataset for bias, fairness, privacy, PII risk, HIPAA compliance, protected health information, PHI, class imbalance, duplicates, outliers, completeness, feature relevance, k-anonymity, feature correlation, collinearity, redundant features, skewness, kurtosis, distribution shape, or mentions AIDRIN. Supports CSV, Excel (.xls/.xlsb/.xlsx/.xlsm), JSON, NumPy (.npz), HDF5 (.h5), and Parquet files.
 ---
 
 # Assessing dataset AI-readiness with AIDRIN
@@ -79,6 +79,7 @@ Dimension → metric mapping for focused requests:
 | Privacy / PII / anonymity | k-anonymity, l-diversity, t-closeness, entropy-risk, single-attribute-risk, multiple-attribute-risk |
 | HIPAA / PHI compliance | hipaa-compliance |
 | Data quality / completeness / duplicates / outliers | completeness, duplicity, outliers |
+| Data structure / distribution shape / collinearity / redundant features | max-pairwise-correlation, skewness, kurtosis |
 | Feature relevance / AI impact | feature-relevance, correlations |
 | Class imbalance | class-imbalance |
 | Full readiness (no specific dimension) | all applicable metrics per the intent table in Step 4 |

--- a/.claude/skills/aidrin/reference/evals.md
+++ b/.claude/skills/aidrin/reference/evals.md
@@ -92,6 +92,28 @@ exit=0
 
 ---
 
+## Scenario 5: Data-structure metrics (zero-arg) — max-pairwise-correlation, skewness, kurtosis
+
+**Commands:**
+```bash
+aidrin run max-pairwise-correlation examples/sample_data/csv/adult.csv
+aidrin run skewness examples/sample_data/csv/adult.csv
+aidrin run kurtosis examples/sample_data/csv/adult.csv
+```
+
+**Outcome:** All three exited 0 and returned valid JSON; output keys match the
+reference entries in metrics.md.
+- `max-pairwise-correlation`: 0.3595 (`ID ~ capital.loss`), 7 numeric features considered.
+- `skewness`: most skewed `capital.gain` (11.95).
+- `kurtosis`: most extreme `capital.gain` (excess 154.80).
+
+Constant/non-numeric columns are excluded automatically; no column arguments needed.
+
+**PASS** — the zero-arg data-structure metrics work end-to-end and their reported
+keys match what the skill documents.
+
+---
+
 ## Summary
 
 | Scenario | Result |
@@ -100,5 +122,6 @@ exit=0
 | 2. Non-CSV schema read + metric run (JSON) | PASS |
 | 3. Absent metric (`data_drift`) → scaffold + run end-to-end | PASS |
 | 4. Error isolation — bad column, exit code behavior | PASS (with caveat: always exits 0) |
+| 5. Data-structure metrics (max-pairwise-correlation, skewness, kurtosis) | PASS |
 
 All core building blocks work. One behavioral note: `aidrin run` always exits 0 regardless of validation errors; errors are indicated only in the JSON body (`"ErrorType": "Validation Error"`). The skill's per-metric isolation pattern handles this correctly in practice, but skill authors should inspect JSON output rather than relying on exit codes.

--- a/.claude/skills/aidrin/reference/metrics.md
+++ b/.claude/skills/aidrin/reference/metrics.md
@@ -4,6 +4,7 @@
 
 - [Invocation & conventions](#invocation--conventions)
 - [Data quality](#data-quality): completeness, duplicity, outliers, row-level-completeness, feature-coverage-ratio, temporal-completeness, null-count-trend
+- [Data structure](#data-structure): max-pairwise-correlation, skewness, kurtosis
 - [Impact on AI](#impact-on-ai): correlations, feature-relevance
 - [Fairness & bias](#fairness--bias): class-imbalance, statistical-rates, representation-rate
 - [Data governance](#data-governance): k-anonymity, l-diversity, t-closeness, entropy-risk, single-attribute-risk, multiple-attribute-risk, hipaa-compliance
@@ -172,6 +173,74 @@ aidrin run temporal-completeness path/to/timeseries.csv --timestamp-column time 
 
 ```bash
 aidrin run null-count-trend path/to/batches.csv --batch-column machine_id --target-columns "temperature,pressure"
+```
+
+---
+
+## Data structure
+
+These three take **no arguments** (like the zero-arg quality baseline) and operate
+on the numeric, non-constant columns.
+
+### max-pairwise-correlation
+
+- **Syntax:** `aidrin run max-pairwise-correlation <file>`
+- **Args (in order):** none
+- **Output keys:**
+  - `Max Pairwise Correlation` — scalar, strongest absolute Pearson correlation between any two numeric features (0–1)
+  - `Most Correlated Pair` — string `"colA ~ colB"`
+  - `Top Correlated Pairs` — list of `{"pair", "correlation"}` objects, ranked
+  - `Numeric Features Considered` — integer count of numeric non-constant columns used
+  - `Max Pairwise Correlation Visualization` — base64 heatmap (stripped by default)
+  - `Description` — string
+- **Direction:** near 1.0 = redundant/collinear features (consider dropping one); near 0 = independent.
+
+**Example:**
+
+```bash
+aidrin run max-pairwise-correlation examples/sample_data/csv/adult.csv
+```
+
+---
+
+### skewness
+
+- **Syntax:** `aidrin run skewness <file>`
+- **Args (in order):** none
+- **Output keys:**
+  - `Skewness` — object mapping each numeric feature to its skewness
+  - `Most Skewed Feature` — string
+  - `Max Absolute Skewness` — scalar
+  - `Numeric Features Considered` — integer
+  - `Skewness Visualization` — base64 bar chart (stripped by default)
+  - `Description` — string
+- **Direction:** |value| far from 0 = asymmetric/long-tailed distribution; ~0 = symmetric.
+
+**Example:**
+
+```bash
+aidrin run skewness examples/sample_data/csv/adult.csv
+```
+
+---
+
+### kurtosis
+
+- **Syntax:** `aidrin run kurtosis <file>`
+- **Args (in order):** none
+- **Output keys:**
+  - `Kurtosis` — object mapping each numeric feature to its excess kurtosis (Fisher; normal = 0)
+  - `Most Extreme Kurtosis Feature` — string
+  - `Max Absolute Excess Kurtosis` — scalar
+  - `Numeric Features Considered` — integer
+  - `Kurtosis Visualization` — base64 bar chart (stripped by default)
+  - `Description` — string
+- **Direction:** positive = heavier tails / more outliers than normal; negative = lighter tails.
+
+**Example:**
+
+```bash
+aidrin run kurtosis examples/sample_data/csv/adult.csv
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,13 @@ All notable changes to AIDRIN are documented here. This project loosely follows
     (`s`/`ms`/… no longer hang on long spans).
   - `null_count_trend` — null counts grouped by a batch column, to spot quality
     regressions (params: `batch_column`, optional `target_columns`).
+
+- **New data-structure metrics** (CLI, Python library, batch, MCP, Globus, and
+  web UI), under a new `data-structure` category with a matching web panel. All
+  three take no parameters and operate on the numeric, non-constant columns:
+  - `max_pairwise_correlation` — strongest absolute pairwise (Pearson)
+    correlation between features, flagging redundant/collinear columns; returns
+    the max, the most-correlated pair, the top pairs, and a heatmap.
+  - `skewness` — per-feature skewness (distribution asymmetry) with a bar chart.
+  - `kurtosis` — per-feature excess kurtosis (Fisher's definition; tail
+    heaviness) with a bar chart.

--- a/aidrin/__init__.py
+++ b/aidrin/__init__.py
@@ -474,6 +474,62 @@ def compute_entropy_risk(quasi_identifiers, file_info):
     return _fn(quasi_identifiers, file_info)
 
 
+def calculate_max_pairwise_correlation(file_info):
+    """Strongest absolute pairwise correlation between numeric features.
+
+    Parameters
+    ----------
+    file_info : tuple
+        ``(file_path, file_name, file_type)``
+
+    Returns
+    -------
+    dict
+        Max correlation, most-correlated pair, top pairs + heatmap, or ``{"Error": str}``.
+    """
+    _eager_celery()
+    from aidrin.structured_data_metrics.max_pairwise_correlation import (
+        max_pairwise_correlation,
+    )
+    return max_pairwise_correlation.apply(args=(file_info,)).get()
+
+
+def calculate_skewness(file_info):
+    """Per-feature skewness (distribution asymmetry) for numeric columns.
+
+    Parameters
+    ----------
+    file_info : tuple
+        ``(file_path, file_name, file_type)``
+
+    Returns
+    -------
+    dict
+        Per-column skewness, most-skewed feature + bar chart, or ``{"Error": str}``.
+    """
+    _eager_celery()
+    from aidrin.structured_data_metrics.skewness import skewness
+    return skewness.apply(args=(file_info,)).get()
+
+
+def calculate_kurtosis(file_info):
+    """Per-feature excess kurtosis (tail heaviness) for numeric columns.
+
+    Parameters
+    ----------
+    file_info : tuple
+        ``(file_path, file_name, file_type)``
+
+    Returns
+    -------
+    dict
+        Per-column excess kurtosis, most-extreme feature + bar chart, or ``{"Error": str}``.
+    """
+    _eager_celery()
+    from aidrin.structured_data_metrics.kurtosis import kurtosis
+    return kurtosis.apply(args=(file_info,)).get()
+
+
 __all__ = [
     "__version__",
     # Data Quality
@@ -491,6 +547,10 @@ __all__ = [
     # Impact on AI
     "calculate_correlations",
     "calculate_feature_relevance",
+    # Data Structure
+    "calculate_max_pairwise_correlation",
+    "calculate_skewness",
+    "calculate_kurtosis",
     # Privacy / Data Governance
     "compute_k_anonymity",
     "compute_l_diversity",

--- a/aidrin/compute/remote.py
+++ b/aidrin/compute/remote.py
@@ -101,6 +101,22 @@ def remote_metric_runner(metric_name, file_path, file_name, file_type, **params)
             result["Custom Criteria Outliers"] = r
         return result
 
+    def _data_structure():
+        """Run selected data-structure sub-metrics and bundle results."""
+        result = {}
+        selected = params.get(
+            "selected", ["max_pairwise_correlation", "skewness", "kurtosis"]
+        )
+        if "max_pairwise_correlation" in selected:
+            result["Max Pairwise Correlation"] = (
+                aidrin.calculate_max_pairwise_correlation(file_info)
+            )
+        if "skewness" in selected:
+            result["Skewness"] = aidrin.calculate_skewness(file_info)
+        if "kurtosis" in selected:
+            result["Kurtosis"] = aidrin.calculate_kurtosis(file_info)
+        return result
+
     def _custom_outlier_targets():
         """Discover selectable custom-outlier targets on the remote file."""
         from aidrin.file_handling.value_iterators import iter_targets
@@ -243,10 +259,16 @@ def remote_metric_runner(metric_name, file_path, file_name, file_type, **params)
     dispatch = {
         "summary_statistics": _summary_statistics,
         "data_quality": _data_quality,
+        "data_structure": _data_structure,
         "custom_outlier_targets": _custom_outlier_targets,
         "completeness": lambda: aidrin.calculate_completeness(file_info),
         "outliers": lambda: aidrin.calculate_outliers(file_info),
         "duplicates": lambda: aidrin.calculate_duplicates(file_info),
+        "max_pairwise_correlation": lambda: aidrin.calculate_max_pairwise_correlation(
+            file_info
+        ),
+        "skewness": lambda: aidrin.calculate_skewness(file_info),
+        "kurtosis": lambda: aidrin.calculate_kurtosis(file_info),
         "row_level_completeness": lambda: aidrin.calculate_row_level_completeness(
             params.get("required_columns", []), file_info
         ),

--- a/aidrin/headless/api.py
+++ b/aidrin/headless/api.py
@@ -16,6 +16,9 @@ from .runners import (
     run_correlations,
     run_differential_privacy,
     run_duplicity,
+    run_kurtosis,
+    run_max_pairwise_correlation,
+    run_skewness,
     run_entropy_risk,
     run_feature_coverage_ratio,
     run_feature_relevance,
@@ -52,6 +55,24 @@ METRIC_REGISTRY: Dict[str, Dict[str, Any]] = {
         "category": "data-quality",
         "description": "Outlier proportions for numerical columns.",
         "runner": run_outliers,
+        "required_args": [],
+    },
+    "max_pairwise_correlation": {
+        "category": "data-structure",
+        "description": "Strongest absolute pairwise correlation between features.",
+        "runner": run_max_pairwise_correlation,
+        "required_args": [],
+    },
+    "skewness": {
+        "category": "data-structure",
+        "description": "Per-feature skewness (distribution asymmetry).",
+        "runner": run_skewness,
+        "required_args": [],
+    },
+    "kurtosis": {
+        "category": "data-structure",
+        "description": "Per-feature excess kurtosis (tail heaviness).",
+        "runner": run_kurtosis,
         "required_args": [],
     },
     "row_level_completeness": {
@@ -441,7 +462,10 @@ def run_metric(
     _log_progress(f"Running {metric_key}...", verbose)
     start_time = time.time()
 
-    if metric_key in {"completeness", "duplicity", "outliers"}:
+    if metric_key in {
+        "completeness", "duplicity", "outliers",
+        "max_pairwise_correlation", "skewness", "kurtosis",
+    }:
         result = metric["runner"](file_path, file_type, file_name)
         result = _maybe_save_images(metric_key, result, save_images, image_dir)
         if strip_visualizations:

--- a/aidrin/headless/runners.py
+++ b/aidrin/headless/runners.py
@@ -10,6 +10,11 @@ from aidrin.structured_data_metrics.completeness import completeness
 from aidrin.structured_data_metrics.correlation_score import calc_correlations
 from aidrin.structured_data_metrics.custom_outliers import custom_outliers
 from aidrin.structured_data_metrics.duplicity import duplicity
+from aidrin.structured_data_metrics.kurtosis import kurtosis
+from aidrin.structured_data_metrics.max_pairwise_correlation import (
+    max_pairwise_correlation,
+)
+from aidrin.structured_data_metrics.skewness import skewness
 from aidrin.structured_data_metrics.feature_coverage_ratio import feature_coverage_ratio
 from aidrin.structured_data_metrics.feature_relevance import (
     data_cleaning,
@@ -86,6 +91,21 @@ def run_completeness(file_path: str, file_type: Optional[str], file_name: Option
 def run_duplicity(file_path: str, file_type: Optional[str], file_name: Optional[str]) -> Dict[str, Any]:
     file_info = _build_file_info(file_path, file_type, file_name)
     return _call_task(duplicity, file_info)
+
+
+def run_max_pairwise_correlation(file_path: str, file_type: Optional[str], file_name: Optional[str]) -> Dict[str, Any]:
+    file_info = _build_file_info(file_path, file_type, file_name)
+    return _call_task(max_pairwise_correlation, file_info)
+
+
+def run_skewness(file_path: str, file_type: Optional[str], file_name: Optional[str]) -> Dict[str, Any]:
+    file_info = _build_file_info(file_path, file_type, file_name)
+    return _call_task(skewness, file_info)
+
+
+def run_kurtosis(file_path: str, file_type: Optional[str], file_name: Optional[str]) -> Dict[str, Any]:
+    file_info = _build_file_info(file_path, file_type, file_name)
+    return _call_task(kurtosis, file_info)
 
 
 def run_outliers(file_path: str, file_type: Optional[str], file_name: Optional[str]) -> Dict[str, Any]:

--- a/aidrin/mcp/server.py
+++ b/aidrin/mcp/server.py
@@ -67,8 +67,9 @@ def list_metrics(category: str | None = None) -> str:
     List all available AIDRIN metrics grouped by category.
 
     Args:
-        category: Optional filter. One of: data-quality, impact-of-data-on-AI,
-                  fairness-and-bias, data-governance, custom_metrics. Omit for all.
+        category: Optional filter. One of: data-quality, data-structure,
+                  impact-of-data-on-AI, fairness-and-bias, data-governance,
+                  custom_metrics. Omit for all.
     """
     return _dumps(list_available_metrics(category=category))
 

--- a/aidrin/structured_data_metrics/kurtosis.py
+++ b/aidrin/structured_data_metrics/kurtosis.py
@@ -1,0 +1,92 @@
+import base64
+import io
+import logging
+
+import matplotlib.pyplot as plt
+import numpy as np
+from celery import Task, shared_task
+from celery.exceptions import SoftTimeLimitExceeded
+
+from aidrin.file_handling.file_parser import read_file
+
+logger = logging.getLogger(__name__)
+
+PRIMARY = "#4485F4"
+TEXT = "#6b7280"
+
+
+@shared_task(bind=True, ignore_result=False)
+def kurtosis(self: Task, file_info):
+    """Per-feature excess kurtosis (tail heaviness) for numeric columns.
+
+    Uses Fisher's definition (normal distribution = 0). Positive = heavier
+    tails / more outliers than normal, negative = lighter tails. Constant
+    columns (undefined kurtosis) are excluded.
+
+    Parameters
+    ----------
+    file_info : tuple
+        ``(file_path, file_name, file_type)`` describing the dataset to read.
+
+    Returns
+    -------
+    dict
+        Per-column excess kurtosis, the most extreme feature, the max absolute
+        value, the count of numeric features considered, a text description, and
+        a base64 bar chart; or ``{"Error": str}``.
+    """
+    try:
+        logger.info("Kurtosis task started")
+        df = read_file(file_info)
+        if len(df) == 0 or len(df.columns) == 0:
+            return {"Error": "Dataset is empty"}
+
+        numeric = df.select_dtypes(include=[np.number])
+        numeric = numeric.loc[:, numeric.nunique(dropna=True) > 1]
+        if numeric.shape[1] == 0:
+            return {"Error": "No non-constant numeric features to score."}
+
+        values = numeric.kurtosis(numeric_only=True).dropna()
+        if values.empty:
+            return {"Error": "No non-constant numeric features to score."}
+
+        kurt_dict = {str(k): float(v) for k, v in values.items()}
+        most_extreme = str(values.abs().idxmax())
+        max_abs = float(values.abs().max())
+
+        ordered = values.reindex(values.abs().sort_values(ascending=True).index)
+        fig, ax = plt.subplots(figsize=(7, max(3, 0.35 * len(ordered))))
+        fig.patch.set_alpha(0)
+        ax.set_facecolor("none")
+        ax.barh([str(c) for c in ordered.index], ordered.values,
+                color=PRIMARY, edgecolor="white")
+        ax.axvline(0, color=TEXT, linewidth=1)
+        ax.set_xlabel("Excess kurtosis", fontsize=10, color=TEXT)
+        ax.set_title("Per-feature excess kurtosis", fontsize=11, color=TEXT)
+        ax.tick_params(colors=TEXT, labelsize=8)
+        for spine in ax.spines.values():
+            spine.set_color(TEXT)
+        fig.tight_layout(pad=0.5)
+
+        img_buf = io.BytesIO()
+        fig.savefig(img_buf, format="png", dpi=150, transparent=True)
+        img_buf.seek(0)
+        img_base64 = base64.b64encode(img_buf.read()).decode("utf-8")
+        plt.close(fig)
+
+        logger.info("Kurtosis task completed: max abs=%.4f", max_abs)
+        return {
+            "Kurtosis": kurt_dict,
+            "Most Extreme Kurtosis Feature": most_extreme,
+            "Max Absolute Excess Kurtosis": max_abs,
+            "Numeric Features Considered": int(numeric.shape[1]),
+            "Kurtosis Visualization": img_base64,
+            "Description": (
+                f"Most extreme feature is '{most_extreme}' (excess kurtosis "
+                f"{values[most_extreme]:.2f}); positive values mean heavier tails than normal."
+            ),
+        }
+
+    except SoftTimeLimitExceeded:
+        logger.error("Kurtosis task timed out")
+        raise Exception("Kurtosis task timed out.")

--- a/aidrin/structured_data_metrics/max_pairwise_correlation.py
+++ b/aidrin/structured_data_metrics/max_pairwise_correlation.py
@@ -1,0 +1,115 @@
+import base64
+import io
+import logging
+
+import matplotlib.pyplot as plt
+import numpy as np
+from celery import Task, shared_task
+from celery.exceptions import SoftTimeLimitExceeded
+
+from aidrin.file_handling.file_parser import read_file
+
+logger = logging.getLogger(__name__)
+
+PRIMARY = "#4485F4"
+TEXT = "#6b7280"
+
+TOP_N = 5
+
+
+@shared_task(bind=True, ignore_result=False)
+def max_pairwise_correlation(self: Task, file_info):
+    """Report the strongest absolute pairwise correlation between features.
+
+    Considers numeric, non-constant columns and computes the absolute Pearson
+    correlation matrix. Surfaces the single most-collinear pair and the top
+    pairs — a compact redundancy signal distinct from the full correlation
+    matrix reported by the correlation-analysis metric.
+
+    Parameters
+    ----------
+    file_info : tuple
+        ``(file_path, file_name, file_type)`` describing the dataset to read.
+
+    Returns
+    -------
+    dict
+        Max absolute correlation, the most-correlated pair, the top pairs, the
+        count of numeric features considered, a text description, and a base64
+        heatmap; or ``{"Error": str}``.
+    """
+    try:
+        logger.info("Max Pairwise Correlation task started")
+        df = read_file(file_info)
+        if len(df) == 0 or len(df.columns) == 0:
+            return {"Error": "Dataset is empty"}
+
+        numeric = df.select_dtypes(include=[np.number])
+        # Drop constant columns — their correlation is undefined (NaN).
+        numeric = numeric.loc[:, numeric.nunique(dropna=True) > 1]
+        if numeric.shape[1] < 2:
+            return {"Error": "Need at least two non-constant numeric features."}
+
+        corr = numeric.corr(numeric_only=True).abs()
+        matrix = corr.to_numpy(copy=True)
+        np.fill_diagonal(matrix, np.nan)
+
+        # Every off-diagonal correlation is NaN when no feature pair shares
+        # overlapping non-null rows (disjoint sparse columns). nanargmax would
+        # raise on an all-NaN slice, so return the {"Error": ...} contract.
+        if np.all(np.isnan(matrix)):
+            return {
+                "Error": "No overlapping non-null rows between numeric features "
+                "to compute a correlation."
+            }
+
+        flat_idx = np.nanargmax(matrix)
+        i, j = np.unravel_index(flat_idx, matrix.shape)
+        cols = list(corr.columns)
+        max_corr = float(matrix[i, j])
+        most_pair = f"{cols[i]} ~ {cols[j]}"
+
+        # Rank unique pairs (upper triangle) by absolute correlation.
+        pairs = []
+        for a in range(len(cols)):
+            for b in range(a + 1, len(cols)):
+                val = matrix[a, b]
+                if not np.isnan(val):
+                    pairs.append((f"{cols[a]} ~ {cols[b]}", float(val)))
+        pairs.sort(key=lambda p: p[1], reverse=True)
+        top_pairs = [{"pair": p, "correlation": round(c, 4)} for p, c in pairs[:TOP_N]]
+
+        fig, ax = plt.subplots(figsize=(6, 5))
+        fig.patch.set_alpha(0)
+        im = ax.imshow(corr.to_numpy(), vmin=0, vmax=1, cmap="Blues")
+        ax.set_xticks(range(len(cols)))
+        ax.set_yticks(range(len(cols)))
+        ax.set_xticklabels(cols, rotation=90, fontsize=7, color=TEXT)
+        ax.set_yticklabels(cols, fontsize=7, color=TEXT)
+        ax.set_title("Absolute pairwise correlation", fontsize=11, color=TEXT)
+        cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+        cbar.ax.tick_params(colors=TEXT, labelsize=7)
+        fig.tight_layout(pad=0.5)
+
+        img_buf = io.BytesIO()
+        fig.savefig(img_buf, format="png", dpi=150, transparent=True)
+        img_buf.seek(0)
+        img_base64 = base64.b64encode(img_buf.read()).decode("utf-8")
+        plt.close(fig)
+
+        logger.info("Max Pairwise Correlation task completed: %.4f", max_corr)
+        return {
+            "Max Pairwise Correlation": max_corr,
+            "Most Correlated Pair": most_pair,
+            "Top Correlated Pairs": top_pairs,
+            "Numeric Features Considered": int(numeric.shape[1]),
+            "Max Pairwise Correlation Visualization": img_base64,
+            "Description": (
+                f"Strongest absolute correlation is {max_corr:.4f} between "
+                f"{most_pair}; values near 1.0 indicate redundant features."
+            ),
+        }
+
+    except SoftTimeLimitExceeded:
+        logger.error("Max Pairwise Correlation task timed out")
+        raise Exception("Max Pairwise Correlation task timed out.")

--- a/aidrin/structured_data_metrics/skewness.py
+++ b/aidrin/structured_data_metrics/skewness.py
@@ -1,0 +1,91 @@
+import base64
+import io
+import logging
+
+import matplotlib.pyplot as plt
+import numpy as np
+from celery import Task, shared_task
+from celery.exceptions import SoftTimeLimitExceeded
+
+from aidrin.file_handling.file_parser import read_file
+
+logger = logging.getLogger(__name__)
+
+PRIMARY = "#4485F4"
+TEXT = "#6b7280"
+
+
+@shared_task(bind=True, ignore_result=False)
+def skewness(self: Task, file_info):
+    """Per-feature skewness (distribution asymmetry) for numeric columns.
+
+    Positive skew = long right tail, negative = long left tail, ~0 = symmetric.
+    Constant columns (undefined skew) are excluded.
+
+    Parameters
+    ----------
+    file_info : tuple
+        ``(file_path, file_name, file_type)`` describing the dataset to read.
+
+    Returns
+    -------
+    dict
+        Per-column skewness, the most-skewed feature, the max absolute
+        skewness, the count of numeric features considered, a text description,
+        and a base64 bar chart; or ``{"Error": str}``.
+    """
+    try:
+        logger.info("Skewness task started")
+        df = read_file(file_info)
+        if len(df) == 0 or len(df.columns) == 0:
+            return {"Error": "Dataset is empty"}
+
+        numeric = df.select_dtypes(include=[np.number])
+        numeric = numeric.loc[:, numeric.nunique(dropna=True) > 1]
+        if numeric.shape[1] == 0:
+            return {"Error": "No non-constant numeric features to score."}
+
+        values = numeric.skew(numeric_only=True).dropna()
+        if values.empty:
+            return {"Error": "No non-constant numeric features to score."}
+
+        skew_dict = {str(k): float(v) for k, v in values.items()}
+        most_skewed = str(values.abs().idxmax())
+        max_abs = float(values.abs().max())
+
+        ordered = values.reindex(values.abs().sort_values(ascending=True).index)
+        fig, ax = plt.subplots(figsize=(7, max(3, 0.35 * len(ordered))))
+        fig.patch.set_alpha(0)
+        ax.set_facecolor("none")
+        ax.barh([str(c) for c in ordered.index], ordered.values,
+                color=PRIMARY, edgecolor="white")
+        ax.axvline(0, color=TEXT, linewidth=1)
+        ax.set_xlabel("Skewness", fontsize=10, color=TEXT)
+        ax.set_title("Per-feature skewness", fontsize=11, color=TEXT)
+        ax.tick_params(colors=TEXT, labelsize=8)
+        for spine in ax.spines.values():
+            spine.set_color(TEXT)
+        fig.tight_layout(pad=0.5)
+
+        img_buf = io.BytesIO()
+        fig.savefig(img_buf, format="png", dpi=150, transparent=True)
+        img_buf.seek(0)
+        img_base64 = base64.b64encode(img_buf.read()).decode("utf-8")
+        plt.close(fig)
+
+        logger.info("Skewness task completed: max abs=%.4f", max_abs)
+        return {
+            "Skewness": skew_dict,
+            "Most Skewed Feature": most_skewed,
+            "Max Absolute Skewness": max_abs,
+            "Numeric Features Considered": int(numeric.shape[1]),
+            "Skewness Visualization": img_base64,
+            "Description": (
+                f"Most skewed feature is '{most_skewed}' (skewness {values[most_skewed]:.2f}); "
+                "values far from 0 indicate asymmetric distributions."
+            ),
+        }
+
+    except SoftTimeLimitExceeded:
+        logger.error("Skewness task timed out")
+        raise Exception("Skewness task timed out.")

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -109,6 +109,11 @@ Examples:
    aidrin run duplicity /path/to/sample_dataset.csv
    aidrin run outliers /path/to/sample_dataset.csv
 
+   # Data structure (no arguments — operate on all numeric, non-constant features)
+   aidrin run max-pairwise-correlation /path/to/sample_dataset.csv
+   aidrin run skewness /path/to/sample_dataset.csv
+   aidrin run kurtosis /path/to/sample_dataset.csv
+
    # Data quality (completeness family — arguments are passed as named --flags)
    aidrin run row-level-completeness /path/to/sample_dataset.csv --required-columns "income,credit_score"
    aidrin run feature-coverage-ratio /path/to/sample_dataset.csv --threshold 0.9
@@ -271,6 +276,15 @@ Available Metrics
    * - Data Quality
      - ``outliers-custom``
      - ``rules-json``
+   * - Data Structure
+     - ``max-pairwise-correlation``
+     - —
+   * - Data Structure
+     - ``skewness``
+     - —
+   * - Data Structure
+     - ``kurtosis``
+     - —
    * - Impact on AI
      - ``correlations``
      - ``columns``

--- a/docs/source/web_usage.rst
+++ b/docs/source/web_usage.rst
@@ -518,7 +518,31 @@ The system returns:
 Data Structure and Organization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Currently, no specific metrics are implemented for this dimension. Future updates may include metrics for assessing dataset schema, format consistency, or organization.
+Assesses structural and distributional properties of the feature set. All three
+metrics operate on the numeric, non-constant columns and require no parameters.
+
+- **Max Pairwise Correlation**:
+
+  - **Method**: Computes the absolute Pearson correlation matrix over numeric
+    features and reports the single strongest pair. Values near 1.0 indicate
+    redundant (near-collinear) features.
+  - **Parameters**: None.
+  - **Result**: The maximum correlation, the most-correlated pair, the top pairs,
+    and an absolute-correlation heatmap.
+
+- **Skewness**:
+
+  - **Method**: Per-feature skewness (distribution asymmetry). Values far from 0
+    indicate long-tailed, asymmetric distributions.
+  - **Parameters**: None.
+  - **Result**: Per-column skewness, the most-skewed feature, and a bar chart.
+
+- **Kurtosis**:
+
+  - **Method**: Per-feature excess kurtosis (Fisher's definition; normal = 0).
+    Positive values mean heavier tails / more outliers than a normal distribution.
+  - **Parameters**: None.
+  - **Result**: Per-column excess kurtosis, the most-extreme feature, and a bar chart.
 
 Notes
 ~~~~~

--- a/tests/unit/test_structure_metrics.py
+++ b/tests/unit/test_structure_metrics.py
@@ -1,0 +1,160 @@
+"""Unit tests for the P3 data-structure metrics.
+
+Covers max_pairwise_correlation, skewness, kurtosis.
+Mirrors test_completeness_extras.py: a minimal always-eager Celery app, a
+``_write_csv`` helper, and invoking each task via ``.apply(args=(...)).get()``.
+"""
+
+import base64
+import binascii
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Stubs — must be installed before any aidrin import
+# ---------------------------------------------------------------------------
+
+if "pkg_resources" not in sys.modules:
+    _pkg = types.ModuleType("pkg_resources")
+
+    class _FakeDist:
+        version = "0.0.0"
+
+    _pkg.get_distribution = lambda _name: _FakeDist()
+    sys.modules["pkg_resources"] = _pkg
+
+from celery import Celery  # noqa: E402
+
+_celery_app = Celery("tests")
+_celery_app.conf.update(task_always_eager=True, task_eager_propagates=True)
+_celery_app.set_default()
+
+from aidrin.structured_data_metrics.max_pairwise_correlation import (  # noqa: E402
+    max_pairwise_correlation,
+)
+from aidrin.structured_data_metrics.skewness import skewness  # noqa: E402
+from aidrin.structured_data_metrics.kurtosis import kurtosis  # noqa: E402
+
+
+def _write_csv(df: pd.DataFrame) -> tuple:
+    tmp = tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w")
+    df.to_csv(tmp.name, index=False)
+    tmp.close()
+    return (tmp.name, os.path.basename(tmp.name), ".csv")
+
+
+def _clean(path):
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _is_base64(s):
+    try:
+        return isinstance(s, str) and len(base64.b64decode(s, validate=True)) > 0
+    except (binascii.Error, ValueError):
+        return False
+
+
+class TestMaxPairwiseCorrelation(unittest.TestCase):
+    def test_detects_perfect_collinearity(self):
+        base = np.arange(50, dtype=float)
+        df = pd.DataFrame({
+            "a": base,
+            "b": base * 2 + 1,   # perfectly correlated with a
+            "c": np.sin(base),
+        })
+        fi = _write_csv(df)
+        try:
+            result = max_pairwise_correlation.apply(args=(fi,)).get()
+        finally:
+            _clean(fi[0])
+        self.assertAlmostEqual(result["Max Pairwise Correlation"], 1.0, places=6)
+        self.assertIn("a ~ b", result["Most Correlated Pair"])
+        self.assertTrue(_is_base64(result["Max Pairwise Correlation Visualization"]))
+
+    def test_insufficient_numeric_features_errors(self):
+        df = pd.DataFrame({"only": [1, 2, 3], "text": ["a", "b", "c"]})
+        fi = _write_csv(df)
+        try:
+            result = max_pairwise_correlation.apply(args=(fi,)).get()
+        finally:
+            _clean(fi[0])
+        self.assertIn("Error", result)
+
+    def test_disjoint_columns_return_error_not_raise(self):
+        # Two non-constant numeric columns with no overlapping non-null rows:
+        # every pairwise correlation is NaN. Must return {"Error"}, not raise.
+        df = pd.DataFrame({
+            "a": [1.0, 2.0, 3.0, np.nan, np.nan, np.nan],
+            "b": [np.nan, np.nan, np.nan, 4.0, 5.0, 6.0],
+        })
+        fi = _write_csv(df)
+        try:
+            result = max_pairwise_correlation.apply(args=(fi,)).get()
+        finally:
+            _clean(fi[0])
+        self.assertIn("Error", result)
+
+
+class TestSkewness(unittest.TestCase):
+    def test_no_numeric_features_errors(self):
+        df = pd.DataFrame({"text": ["a", "b", "c"], "const": [5, 5, 5]})
+        fi = _write_csv(df)
+        try:
+            result = skewness.apply(args=(fi,)).get()
+        finally:
+            _clean(fi[0])
+        self.assertIn("Error", result)
+
+    def test_reports_skew(self):
+        df = pd.DataFrame({
+            "symmetric": [-2, -1, 0, 1, 2] * 4,
+            "right_tail": [1, 1, 1, 1, 100] * 4,
+        })
+        fi = _write_csv(df)
+        try:
+            result = skewness.apply(args=(fi,)).get()
+        finally:
+            _clean(fi[0])
+        self.assertIn("right_tail", result["Skewness"])
+        self.assertEqual(result["Most Skewed Feature"], "right_tail")
+        self.assertGreater(result["Max Absolute Skewness"], 1.0)
+        self.assertTrue(_is_base64(result["Skewness Visualization"]))
+
+
+class TestKurtosis(unittest.TestCase):
+    def test_reports_kurtosis(self):
+        df = pd.DataFrame({
+            "heavy_tail": [0, 0, 0, 0, 0, 0, 0, 0, 50, -50] * 3,
+            "uniform_ish": list(range(30)),
+        })
+        fi = _write_csv(df)
+        try:
+            result = kurtosis.apply(args=(fi,)).get()
+        finally:
+            _clean(fi[0])
+        self.assertIn("heavy_tail", result["Kurtosis"])
+        self.assertEqual(result["Most Extreme Kurtosis Feature"], "heavy_tail")
+        self.assertGreater(result["Max Absolute Excess Kurtosis"], 0.0)
+        self.assertTrue(_is_base64(result["Kurtosis Visualization"]))
+
+    def test_no_numeric_features_errors(self):
+        df = pd.DataFrame({"text": ["a", "b", "c"], "const": [5, 5, 5]})
+        fi = _write_csv(df)
+        try:
+            result = kurtosis.apply(args=(fi,)).get()
+        finally:
+            _clean(fi[0])
+        self.assertIn("Error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/routes/metrics.py
+++ b/web/routes/metrics.py
@@ -31,6 +31,11 @@ from aidrin.structured_data_metrics.row_level_completeness import row_level_comp
 from aidrin.structured_data_metrics.temporal_completeness import temporal_completeness
 from aidrin.structured_data_metrics.correlation_score import calc_correlations
 from aidrin.structured_data_metrics.duplicity import duplicity
+from aidrin.structured_data_metrics.kurtosis import kurtosis
+from aidrin.structured_data_metrics.max_pairwise_correlation import (
+    max_pairwise_correlation,
+)
+from aidrin.structured_data_metrics.skewness import skewness
 from aidrin.structured_data_metrics.FAIRness_datacite import categorize_keys_fair
 from aidrin.structured_data_metrics.FAIRness_dcat import (
     categorize_metadata,
@@ -290,6 +295,69 @@ def data_quality():
             return store_result("metrics.data_quality", final_dict)
 
     return get_result_or_default("metrics.data_quality", file_path, file_name)
+
+
+# ---------------------------------------------------------------------------
+# Data Structure
+# ---------------------------------------------------------------------------
+
+@metrics_bp.route("/data-structure", methods=["GET", "POST"])
+def data_structure():
+    final_dict = {}
+    file_path = session.get("uploaded_file_path")
+    file_name = session.get("uploaded_file_name")
+    file_type = session.get("uploaded_file_type")
+    file_info = build_file_info(file_path, file_name, file_type)
+
+    if request.method == "POST":
+        start_time = time.time()
+        selected = [
+            m for m in (
+                "max pairwise correlation", "skewness", "kurtosis",
+            ) if request.form.get(m) == "yes"
+        ]
+        metric_time_log.info("Data Structure request started: %s", selected)
+
+        tracer = get_tracer()
+        with tracer.start_as_current_span("metric.data_structure") as span:
+            span.set_attribute("metric.pillar", "data_structure")
+            span.set_attribute("metric.selected", ",".join(selected))
+            span.set_attribute("file.name", file_name or "")
+            span.set_attribute("file.type", file_type or "")
+
+            try:
+                if "max pairwise correlation" in selected:
+                    t0 = time.time()
+                    with tracer.start_as_current_span("metric.max_pairwise_correlation"):
+                        final_dict["Max Pairwise Correlation"] = max_pairwise_correlation(
+                            file_info
+                        )
+                    metric_time_log.info(
+                        "Max Pairwise Correlation took %.2f seconds", time.time() - t0
+                    )
+
+                if "skewness" in selected:
+                    t0 = time.time()
+                    with tracer.start_as_current_span("metric.skewness"):
+                        final_dict["Skewness"] = skewness(file_info)
+                    metric_time_log.info("Skewness took %.2f seconds", time.time() - t0)
+
+                if "kurtosis" in selected:
+                    t0 = time.time()
+                    with tracer.start_as_current_span("metric.kurtosis"):
+                        final_dict["Kurtosis"] = kurtosis(file_info)
+                    metric_time_log.info("Kurtosis took %.2f seconds", time.time() - t0)
+
+            except Exception as e:
+                metric_time_log.error("Data Structure error: %s", e, exc_info=True)
+                return jsonify({"error": f"{type(e).__name__}: {e}"}), 200
+
+            duration_ms = (time.time() - start_time) * 1000
+            span.set_attribute("metric.duration_ms", duration_ms)
+            metric_time_log.info("Data Structure completed in %.2f seconds", time.time() - start_time)
+            return store_result("metrics.data_structure", final_dict)
+
+    return get_result_or_default("metrics.data_structure", file_path, file_name)
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/js/inspector.js
+++ b/web/static/js/inspector.js
@@ -74,6 +74,7 @@ function showPanel(panelId, pushHistory) {
 // Panel ID → backend cache metric name mapping
 const _panelCacheMap = {
   "data-quality": "data_quality",
+  "data-structure": "data_structure",
   fairness: "fairness",
   "correlation-analysis": "correlation_analysis",
   "feature-relevance": "feature_relevance",
@@ -304,6 +305,11 @@ function workspaceSubmit(targetUrl) {
     // Map route URLs to remote_metric_runner metric names
     const urlToMetrics = {
       "/data-quality": ["completeness", "outliers", "duplicates"],
+      "/data-structure": [
+        "max_pairwise_correlation",
+        "skewness",
+        "kurtosis",
+      ],
       "/fairness": ["representation_rate", "statistical_rates"],
       "/feature-relevance": ["feature_relevance"],
       "/correlation-analysis": ["correlations"],
@@ -414,6 +420,29 @@ function workspaceSubmit(targetUrl) {
         }
         remoteParams.stop_after_outliers =
           gFormData.get("stop_after_outliers") === "yes";
+      }
+      if (selected.length === 0) {
+        if (typeof showToast === "function")
+          showToast("Please select at least one metric", "error");
+        return;
+      }
+      remoteParams.selected = selected;
+      remoteDisplayName = selectedNames.join(", ");
+    } else if (targetUrl === "/data-structure") {
+      remoteName = "data_structure";
+      const selected = [];
+      const selectedNames = [];
+      if (gFormData.get("max pairwise correlation") === "yes") {
+        selected.push("max_pairwise_correlation");
+        selectedNames.push("Max Pairwise Correlation");
+      }
+      if (gFormData.get("skewness") === "yes") {
+        selected.push("skewness");
+        selectedNames.push("Skewness");
+      }
+      if (gFormData.get("kurtosis") === "yes") {
+        selected.push("kurtosis");
+        selectedNames.push("Kurtosis");
       }
       if (selected.length === 0) {
         if (typeof showToast === "function")
@@ -2020,6 +2049,7 @@ function pollAsyncMetric(taskId, metricName, cacheKey, checkUrlBase) {
   // Human-readable metric names for the spinner card
   const metricDisplayNames = {
     data_quality: "Data Quality",
+    data_structure: "Data Structure",
     completeness: "Column-Level Completeness",
     outliers: "Outliers",
     duplicates: "Duplicity",

--- a/web/static/js/inspector.js
+++ b/web/static/js/inspector.js
@@ -305,11 +305,7 @@ function workspaceSubmit(targetUrl) {
     // Map route URLs to remote_metric_runner metric names
     const urlToMetrics = {
       "/data-quality": ["completeness", "outliers", "duplicates"],
-      "/data-structure": [
-        "max_pairwise_correlation",
-        "skewness",
-        "kurtosis",
-      ],
+      "/data-structure": ["max_pairwise_correlation", "skewness", "kurtosis"],
       "/fairness": ["representation_rate", "statistical_rates"],
       "/feature-relevance": ["feature_relevance"],
       "/correlation-analysis": ["correlations"],

--- a/web/templates/_components/sidebar.html
+++ b/web/templates/_components/sidebar.html
@@ -112,6 +112,7 @@
         <svg class="w-4 h-4 transition-transform text-gray-400" id="pillar-structure-arrow" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5"/></svg>
       </button>
       <ul id="pillar-structure" class="hidden pl-9 space-y-1 pt-1">
+        <li><button onclick="showPanel('data-structure')" class="sidebar-metric-item w-full text-left p-1.5 rounded-md text-sm hover:bg-black/10 dark:hover:bg-white/10 transition-colors" style="color: var(--textColorSecondary);">Data Structure</button></li>
         {% if file_type == '.csv' %}
         <li><button onclick="showPanel('custom-metrics')" class="sidebar-metric-item w-full text-left p-1.5 rounded-md text-sm hover:bg-black/10 dark:hover:bg-white/10 transition-colors" style="color: var(--textColorSecondary);">Custom Metrics</button></li>
         {% else %}

--- a/web/templates/_panels/_data_structure.html
+++ b/web/templates/_panels/_data_structure.html
@@ -1,0 +1,43 @@
+<!-- Data Structure metric panel -->
+<div id="panel-data-structure" class="metric-panel hidden">
+  <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-5">
+    <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Data Structure</h2>
+    <form id="form-data-structure" method="post" enctype="multipart/form-data">
+      <input type="file" id="file" name="file" style="display: none;" />
+      <div id="checkboxContainer_structure" class="checkboxContainer">
+        <div class="checkboxContainerIndividual">
+          <label class="material-checkbox">
+            <input type="checkbox" name="max pairwise correlation" onchange="toggleValue(this)" />
+            <span class="checkmark"></span>
+            Check max pairwise correlation
+            <span class="info-icon">i<span class="info-text">This option reports the strongest absolute correlation between any two numeric features, flagging redundant (near-collinear) features.</span></span>
+          </label>
+        </div>
+
+        <div class="checkboxContainerIndividual">
+          <label class="material-checkbox">
+            <input type="checkbox" name="skewness" onchange="toggleValue(this)" />
+            <span class="checkmark"></span>
+            Check skewness
+            <span class="info-icon">i<span class="info-text">This option reports per-feature skewness (distribution asymmetry). Values far from 0 indicate long-tailed, asymmetric distributions.</span></span>
+          </label>
+        </div>
+
+        <div class="checkboxContainerIndividual">
+          <label class="material-checkbox">
+            <input type="checkbox" name="kurtosis" onchange="toggleValue(this)" />
+            <span class="checkmark"></span>
+            Check kurtosis
+            <span class="info-icon">i<span class="info-text">This option reports per-feature excess kurtosis (tail heaviness). Positive values mean heavier tails / more outliers than a normal distribution.</span></span>
+          </label>
+        </div>
+      </div>
+      <div class="flex items-center justify-end pt-4 mt-4 border-t border-gray-200 dark:border-gray-700">
+        <button type="button" onclick="withSubmitGuard(this, () => workspaceSubmit('/data-structure'));"
+                class="px-5 py-2.5 text-sm font-medium text-white rounded-lg cursor-pointer bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 transition-colors">
+          Submit
+        </button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/web/templates/inspector.html
+++ b/web/templates/inspector.html
@@ -57,6 +57,7 @@
         <div id="panels-container">
           {% include '_panels/_data_overview.html' %}
           {% include '_panels/_data_quality.html' %}
+          {% include '_panels/_data_structure.html' %}
           {% include '_panels/_feature_relevance.html' %}
           {% include '_panels/_correlation_analysis.html' %}
           {% include '_panels/_fairness.html' %}


### PR DESCRIPTION
## Summary

Adds three **Data Structure & Organization (P3)** metrics, under a new `data-structure` category, wired across all interfaces (Python library, CLI, MCP, Globus, and the web UI):

- **`max_pairwise_correlation`**: strongest absolute pairwise (Pearson) correlation between numeric features, surfacing redundant/collinear columns. Returns the max, the most-correlated pair, the top pairs, and a heatmap.
- **`skewness`**: per-feature skewness (distribution asymmetry) with a bar chart.
- **`kurtosis`**: per-feature excess kurtosis (Fisher's definition; tail heaviness) with a bar chart.

All three take no parameters and operate on the numeric, non-constant columns.

## Interfaces

- **CLI / MCP**: auto-discovered from `METRIC_REGISTRY` (no per-metric wiring; no new params).
- **Python API**: `calculate_max_pairwise_correlation`, `calculate_skewness`, `calculate_kurtosis`.
- **Globus**: dispatch entries plus a `_data_structure` bundle in `compute/remote.py`.
- **Web**: new **Data Structure** panel/route, sidebar entry (under the existing `pillar-structure` group), and `inspector.js` wiring.

## Tests

`tests/unit/test_structure_metrics.py` (7 tests) covering happy paths, constant-column exclusion, insufficient/no-numeric-feature errors, and the disjoint-columns edge case (non-overlapping non-null rows → `{"Error": ...}` rather than an uncaught `ValueError`).

## Docs

Updated `CHANGELOG.md`, `docs/source/cli_usage.rst` (examples + metrics table), and `docs/source/web_usage.rst` (Data Structure panel).