### PR TITLE
Fix TypeError on datasets with array-valued columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,20 @@ All notable changes to AIDRIN are documented here. This project loosely follows
   - `skewness` — per-feature skewness (distribution asymmetry) with a bar chart.
   - `kurtosis` — per-feature excess kurtosis (Fisher's definition; tail
     heaviness) with a bar chart.
+
+### Fixed
+
+- **Datasets with array-valued columns no longer break the summary or
+  duplicity.** Object columns holding arrays/lists/dicts — routine in parquet,
+  HDF5 and JSON (e.g. a per-node measurement array) — are unhashable, and
+  `nunique()` / `value_counts()` / `duplicated()` all hash. This raised
+  `TypeError: unhashable type: 'numpy.ndarray'`, which surfaced as a failed web
+  summary ("An internal error occurred") and made the `duplicity` metric — and
+  therefore the whole `aidrin data-quality` bundle — unusable on such files.
+
+  Normalization now lives in a shared helper,
+  `aidrin/file_handling/hashable_utils.py` (`make_hashable`, `hashable_series`,
+  `hashable_frame`, `safe_nunique`), used by both the duplicity metric and the
+  web summary route. Values are converted to nested tuples, which preserves
+  equality so distinct-counting and duplicate detection stay correct.
+  `duplicity._make_hashable` remains as an alias for backwards compatibility.

--- a/aidrin/file_handling/hashable_utils.py
+++ b/aidrin/file_handling/hashable_utils.py
@@ -1,0 +1,78 @@
+"""Normalize unhashable cell values so pandas set-based operations work.
+
+pandas operations that hash values — ``nunique()``, ``duplicated()``,
+``value_counts()``, ``groupby()`` — raise ``TypeError: unhashable type`` on
+object columns holding arrays, lists, dicts or sets. Parquet, HDF5 and JSON
+datasets routinely carry such columns (e.g. a per-node measurement array), so
+any code that counts distinct values must normalize them first or it will fail
+on a whole class of real datasets.
+
+Converting to nested tuples preserves value equality, so distinct-counting and
+duplicate detection stay correct — two rows with equal arrays still compare
+equal after conversion.
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def make_hashable(value):
+    """Recursively convert an unhashable value to a hashable equivalent.
+
+    Arrays/lists/tuples become tuples, dicts become sorted key/value tuples, and
+    sets become sorted tuples. Scalars pass through untouched.
+    """
+    if isinstance(value, np.ndarray):
+        return tuple(make_hashable(v) for v in value.tolist())
+    if isinstance(value, (list, tuple)):
+        return tuple(make_hashable(v) for v in value)
+    if isinstance(value, dict):
+        return tuple(sorted((k, make_hashable(v)) for k, v in value.items()))
+    if isinstance(value, (set, frozenset)):
+        return tuple(sorted(make_hashable(v) for v in value))
+    return value
+
+
+def is_unhashable_column(series: pd.Series) -> bool:
+    """Whether *series* holds values pandas cannot hash.
+
+    Only object columns can carry such values; the first non-null value is used
+    as the probe, matching how the rest of the codebase samples column contents.
+    """
+    if series.dtype != object:
+        return False
+    non_null = series.dropna()
+    if non_null.empty:
+        return False
+    return isinstance(
+        non_null.iloc[0], (np.ndarray, list, tuple, dict, set, frozenset)
+    )
+
+
+def hashable_series(series: pd.Series) -> pd.Series:
+    """Return *series* with unhashable values converted, else unchanged."""
+    if is_unhashable_column(series):
+        return series.apply(make_hashable)
+    return series
+
+
+def hashable_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of *df* with every unhashable object column converted."""
+    out = df.copy()
+    for col in out.columns:
+        if is_unhashable_column(out[col]):
+            out[col] = out[col].apply(make_hashable)
+    return out
+
+
+def safe_nunique(series: pd.Series, dropna: bool = True) -> int:
+    """``nunique()`` that tolerates unhashable values.
+
+    Tries the fast path first and only converts on failure, so mixed columns
+    (whose first value looks hashable but whose later values do not) are handled
+    too — a case the first-value probe alone would miss.
+    """
+    try:
+        return int(series.nunique(dropna=dropna))
+    except TypeError:
+        return int(series.apply(make_hashable).nunique(dropna=dropna))

--- a/aidrin/structured_data_metrics/duplicity.py
+++ b/aidrin/structured_data_metrics/duplicity.py
@@ -4,17 +4,14 @@ from celery import Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 
 from aidrin.file_handling.file_parser import read_file
+from aidrin.file_handling.hashable_utils import hashable_frame, make_hashable
 
 logger = logging.getLogger(__name__)
 
-
-def _make_hashable(val):
-    """Convert unhashable types (lists, dicts) to hashable equivalents."""
-    if isinstance(val, list):
-        return tuple(_make_hashable(v) for v in val)
-    elif isinstance(val, dict):
-        return tuple(sorted((k, _make_hashable(v)) for k, v in val.items()))
-    return val
+# Backwards-compatible alias: this module was the original home of the
+# conversion helper, which now lives in file_handling.hashable_utils so the
+# summary route and other metrics can share it.
+_make_hashable = make_hashable
 
 
 @shared_task(bind=True, ignore_result=False)
@@ -40,15 +37,9 @@ def duplicity(self: Task, file_info):
         file = read_file(file_info)
         dup_dict = {}
 
-        # Check if any columns contain unhashable types (lists, dicts)
-        # and convert them to hashable equivalents for duplicate detection
-        hashable_file = file.copy()
-        for col in hashable_file.columns:
-            if hashable_file[col].dtype == object:
-                # Check first non-null value to see if it's unhashable
-                first_val = hashable_file[col].dropna().iloc[0] if not hashable_file[col].dropna().empty else None
-                if isinstance(first_val, (list, dict)):
-                    hashable_file[col] = hashable_file[col].apply(_make_hashable)
+        # Columns holding arrays/lists/dicts (common in parquet/HDF5/JSON) are
+        # unhashable, and duplicated() hashes rows — normalize them first.
+        hashable_file = hashable_frame(file)
 
         # Calculate the proportion of duplicate values
         duplicate_proportions = hashable_file.duplicated().sum() / len(hashable_file)

--- a/tests/unit/test_hashable_utils.py
+++ b/tests/unit/test_hashable_utils.py
@@ -1,0 +1,121 @@
+"""Tests for the shared unhashable-value normalization helper.
+
+Regression coverage for datasets whose object columns hold arrays/lists/dicts
+(routine in parquet, HDF5 and JSON). Before this helper, nunique()/duplicated()/
+value_counts() raised TypeError on such columns, breaking the duplicity metric
+and the web summary.
+"""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+import numpy as np
+import pandas as pd
+
+if "pkg_resources" not in sys.modules:
+    _pkg = types.ModuleType("pkg_resources")
+
+    class _FakeDist:
+        version = "0.0.0"
+
+    _pkg.get_distribution = lambda _name: _FakeDist()
+    sys.modules["pkg_resources"] = _pkg
+
+from aidrin.file_handling.hashable_utils import (  # noqa: E402
+    hashable_frame,
+    hashable_series,
+    is_unhashable_column,
+    make_hashable,
+    safe_nunique,
+)
+
+
+class TestMakeHashable(unittest.TestCase):
+    def test_ndarray_becomes_tuple(self):
+        self.assertEqual(make_hashable(np.array([1, 2, 3])), (1, 2, 3))
+
+    def test_nested_ndarray(self):
+        self.assertEqual(make_hashable(np.array([[1, 2], [3, 4]])), ((1, 2), (3, 4)))
+
+    def test_list_and_dict_and_set(self):
+        self.assertEqual(make_hashable([1, [2, 3]]), (1, (2, 3)))
+        self.assertEqual(make_hashable({"b": 1, "a": 2}), (("a", 2), ("b", 1)))
+        self.assertEqual(make_hashable({3, 1, 2}), (1, 2, 3))
+
+    def test_scalars_pass_through(self):
+        for v in (1, "x", 2.5, None, True):
+            self.assertEqual(make_hashable(v), v)
+
+    def test_equal_arrays_convert_equal(self):
+        # Distinct-counting must stay correct after conversion.
+        self.assertEqual(make_hashable(np.array([1, 2])), make_hashable(np.array([1, 2])))
+
+
+class TestColumnHelpers(unittest.TestCase):
+    def test_detects_unhashable_column(self):
+        arr = pd.Series([np.array([1, 2]), np.array([3, 4])])
+        self.assertTrue(is_unhashable_column(arr))
+        self.assertFalse(is_unhashable_column(pd.Series([1, 2, 3])))
+        self.assertFalse(is_unhashable_column(pd.Series(["a", "b"])))
+        self.assertFalse(is_unhashable_column(pd.Series([], dtype=object)))
+
+    def test_hashable_series_enables_nunique(self):
+        s = pd.Series([np.array([1, 2]), np.array([1, 2]), np.array([3, 4])])
+        with self.assertRaises(TypeError):
+            s.nunique()
+        self.assertEqual(hashable_series(s).nunique(), 2)
+
+    def test_hashable_frame_enables_duplicated(self):
+        df = pd.DataFrame({
+            "arr": [np.array([1, 2]), np.array([1, 2]), np.array([9, 9])],
+            "x": [1, 1, 2],
+        })
+        with self.assertRaises(TypeError):
+            df.duplicated()
+        self.assertEqual(int(hashable_frame(df).duplicated().sum()), 1)
+
+    def test_safe_nunique_handles_both_paths(self):
+        self.assertEqual(safe_nunique(pd.Series([1, 1, 2])), 2)
+        self.assertEqual(safe_nunique(pd.Series([np.array([1]), np.array([1])])), 1)
+
+    def test_safe_nunique_handles_mixed_column(self):
+        # First value is hashable, a later one is not — the first-value probe
+        # alone would miss this, so safe_nunique must fall back on TypeError.
+        s = pd.Series(["a", np.array([1, 2])], dtype=object)
+        self.assertEqual(safe_nunique(s), 2)
+
+
+class TestDuplicityOnArrayColumns(unittest.TestCase):
+    """End-to-end regression: duplicity previously crashed on parquet arrays."""
+
+    def test_duplicity_runs_on_ndarray_parquet(self):
+        from celery import Celery
+
+        app = Celery("tests")
+        app.conf.update(task_always_eager=True, task_eager_propagates=True)
+        app.set_default()
+        from aidrin.structured_data_metrics.duplicity import duplicity
+
+        df = pd.DataFrame({
+            "arr": [np.array([1, 2]), np.array([1, 2]), np.array([3, 4])],
+            "x": [1, 1, 2],
+        })
+        tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+        df.to_parquet(tmp.name, index=False)
+        tmp.close()
+        try:
+            result = duplicity.apply(
+                args=((tmp.name, os.path.basename(tmp.name), ".parquet"),)
+            ).get()
+        finally:
+            os.unlink(tmp.name)
+        self.assertIn("Duplicity scores", result)
+        score = result["Duplicity scores"]["Overall duplicity of the dataset"]
+        self.assertAlmostEqual(float(score), 1 / 3, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -18,6 +18,7 @@ from flask import (
 )
 from werkzeug.utils import secure_filename
 from aidrin.file_handling.file_parser import SUPPORTED_FILE_TYPES, READER_MAP
+from aidrin.file_handling.hashable_utils import hashable_series, safe_nunique
 from aidrin.file_handling.readers.hdf5_reader import hdf5Reader
 from web.routes.utils import (
     clear_all_user_cache,
@@ -515,13 +516,20 @@ def summary_statistics():
 
         categorical_summary = {}
         for col in categorical_columns:
-            counts = df[col].value_counts(dropna=True)
-            count = int(df[col].notna().sum())
+            # value_counts() and nunique() both hash, so a column holding
+            # arrays/lists/dicts (parquet/HDF5/JSON) would raise and take the
+            # whole summary down. Normalize such columns first.
+            series = hashable_series(df[col])
+            counts = series.value_counts(dropna=True)
+            count = int(series.notna().sum())
             freq = int(counts.iloc[0]) if not counts.empty else 0
+            top = str(counts.index[0]) if not counts.empty else "—"
+            if len(top) > 80:
+                top = top[:77] + "..."
             categorical_summary[str(col)] = {
                 "count": count,
-                "unique": int(df[col].nunique(dropna=True)),
-                "top": str(counts.index[0]) if not counts.empty else "—",
+                "unique": safe_nunique(series, dropna=True),
+                "top": top,
                 "freq": freq,
                 "freq_pct": round(freq / count * 100, 1) if count else 0.0,
             }


### PR DESCRIPTION
# Description

Datasets whose object columns hold arrays/lists/dicts — routine in parquet, HDF5 and JSON — raise `TypeError: unhashable type: 'numpy.ndarray'`, because `nunique()`, `value_counts()` and `duplicated()` all hash values.

This has two user-visible effects:

1. **The web summary fails.** The categorical-summary loop in `web/routes/core.py` calls `value_counts()` and `nunique()`; the exception is swallowed by a broad `except` and the UI just shows *"An internal error occurred"*, with no indication of the cause.
2. **`duplicity` is unusable** on such files — and since it is part of the bundle, the whole `aidrin data-quality` command fails too.

`duplicity.py` already had a local `_make_hashable`, but it only covered `list`/`dict` (never `numpy.ndarray`), and the summary route did not use it at all.

## Fix

Promote the normalization to a shared helper, `aidrin/file_handling/hashable_utils.py`, and use it at both sites:

- `make_hashable` / `hashable_series` / `hashable_frame` convert to nested tuples. Tuples preserve value equality, so distinct-counting and duplicate detection remain correct — two rows with equal arrays still compare equal.
- `safe_nunique` tries the fast path and only converts on `TypeError`, so **mixed** columns (first value hashable, a later one not) are handled too — a case a first-value probe alone would miss.
- The categorical summary normalizes before *both* `value_counts()` and `nunique()`, and truncates over-long `top` values so an array cannot bloat the response.
- `duplicity._make_hashable` is kept as an alias for backwards compatibility (it is imported elsewhere).

## Verification

On a parquet with four `numpy.ndarray` columns (15,285 rows x 35 cols):

| | Before | After |
|---|---|---|
| Web summary | "An internal error occurred" | 18 numerical + 13 categorical features summarized |
| `duplicity` | `TypeError` | `0.0000` |
| `aidrin data-quality` | `TypeError` | Completeness `0.9714` / Duplicity `0.0000` / Outliers `0.0308` |

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] This change requires a documentation update

# Checklist:

- [X] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [X] I have commented my code
- [X] My code requires documentation updates, and I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

Adds `tests/unit/test_hashable_utils.py` (11 tests), including an end-to-end regression on an actual ndarray parquet. No existing test used an array column, which is why this went unnoticed.
