### PR TITLE
Fix: #121 Prefer full HDF5 dataset paths as DataFrame column names

### DIFF
--- a/aidrin/file_handling/readers/hdf5_reader.py
+++ b/aidrin/file_handling/readers/hdf5_reader.py
@@ -242,14 +242,24 @@ class hdf5Reader(BaseFileReader):
             return []
 
     def _column_name_from_path(self, path, used_names):
-        """Pick a unique DataFrame column name for an HDF5 dataset path."""
+        """Prefer the full dataset path so group/station context is preserved.
+
+        Examples: ``S_01_01/X``, ``D1.fill_starts``. Falls back only if the full
+        path is already used as a column name (duplicate selection).
+        """
+        full = path.strip("/") or path
+        if full not in used_names:
+            return full
         short = path.split("/")[-1] or path
         if short not in used_names:
             return short
-        dotted = path.strip("/").replace("/", ".")
+        dotted = full.replace("/", ".")
         if dotted not in used_names:
             return dotted
-        return path
+        suffix = 2
+        while f"{full}_{suffix}" in used_names:
+            suffix += 1
+        return f"{full}_{suffix}"
 
     def _read_compatible_dataset_paths(self, paths):
         """Merge multiple same-length 1D datasets into one DataFrame."""
@@ -353,7 +363,7 @@ class hdf5Reader(BaseFileReader):
             data = obj[()]
             data = self._apply_fill_values(data, obj, path)
 
-            col_name = path.split("/")[-1] or path
+            col_name = self._column_name_from_path(path, set())
             if getattr(data, "ndim", 0) == 0:
                 df = pd.DataFrame({col_name: [data]})
             elif data.ndim == 1:

--- a/tests/unit/test_hdf5_reader.py
+++ b/tests/unit/test_hdf5_reader.py
@@ -480,9 +480,21 @@ class TestGroupedEqsimLayout:
 
         assert df is not None
         assert df.shape == (100, 3)
-        assert list(df.columns) == ["X", "Y", "Z"]
-        assert (df["X"] == 0.0).any()
-        assert df["X"].isna().sum() == 0
+        assert list(df.columns) == ["S_01_01/X", "S_01_01/Y", "S_01_01/Z"]
+        assert (df["S_01_01/X"] == 0.0).any()
+        assert df["S_01_01/X"].isna().sum() == 0
+
+    def test_read_selected_waveforms_keeps_station_path_context(self, tmp_path, logger):
+        """Selecting the same short names from two stations stays distinguishable."""
+        fpath = str(tmp_path / "rechdf5.h5")
+        _make_mock_rechdf5(fpath, nx=2, ny=2, npts=50)
+
+        keys = ["S_01_01/X", "S_01_02/X"]
+        df = hdf5Reader(fpath, logger, selected_keys=keys).read()
+
+        assert df is not None
+        assert df.shape == (50, 2)
+        assert list(df.columns) == ["S_01_01/X", "S_01_02/X"]
 
     def test_pandas_hdf5_stays_legacy_not_multi_dataset(self, logger):
         from pathlib import Path


### PR DESCRIPTION
# Related Issues / Pull Requests

Follow-up to #121 (EQSIM/rechdf5 HDF5 path context)
Builds on #118 (dataset selection / no blind flatten)

# Description

Prefer full HDF5 dataset paths as DataFrame column names when reading selected datasets (for example `S_01_01/X` instead of `X`).

This preserves station/group context for EQSIM-style hierarchical files so columns from different groups stay distinguishable. Valid zero fill behavior from #118 is unchanged.

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [x] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
