### PR TITLE
Add status badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # AIDRIN – AI Data Readiness Infrastructure
 
+[![PyPI](https://img.shields.io/pypi/v/aidrin?logo=pypi&logoColor=white)](https://pypi.org/project/aidrin/)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue?logo=python&logoColor=white)](https://pypi.org/project/aidrin/)
+[![DOI](https://img.shields.io/badge/DOI-10.1145%2F3676288.3676296-orange)](https://doi.org/10.1145/3676288.3676296)
+
+[![Tests](https://img.shields.io/github/actions/workflow/status/idtlab/AIDRIN/tests.yml?branch=develop&label=tests&logo=github)](https://github.com/idtlab/AIDRIN/actions/workflows/tests.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/idtlab/AIDRIN/build.yml?branch=develop&label=build&logo=github)](https://github.com/idtlab/AIDRIN/actions/workflows/build.yml)
+[![Docs](https://img.shields.io/readthedocs/aidrin?logo=readthedocs&logoColor=white)](https://aidrin.readthedocs.io/en/latest/)
+[![Dependencies](https://img.shields.io/librariesio/github/idtlab/AIDRIN)](https://libraries.io/github/idtlab/AIDRIN)
+
 **AIDRIN** (AI Data Readiness Infrastructure) is a lightweight, open-source tool designed to evaluate the readiness of datasets for AI and machine learning workflows. It provides an intuitive web interface to assess dataset quality, completeness, and structure through quantitative metrics.
 
 For installation, usage, and contribution guidelines, please refer to the [AIDRIN documentation](https://aidrin.readthedocs.io/en/latest/).


### PR DESCRIPTION
Adds two rows of badges to the top of `README.md`. Every URL was probed against shields.io before being committed, and each one renders a real value today.

## Release identity

| Badge | Source | Renders |
|---|---|---|
| PyPI version | `pypi/v/aidrin` | `v2026.7.1` |
| Python | static | `3.10 \| 3.11 \| 3.12 \| 3.13` |
| DOI | static | `10.1145/3676288.3676296` (from `CITATION.cff`) |

## Project health

| Badge | Source | Renders |
|---|---|---|
| Tests | `tests.yml?branch=develop` | `passing` |
| Build | `build.yml?branch=develop` | `passing` |
| Docs | `readthedocs/aidrin` | `passing` |
| Dependencies | `librariesio/github/idtlab/AIDRIN` | `1 out of date` |

## Why Python is static

`pypi/pyversions/aidrin` renders **"missing"** in red. `pyproject.toml` declares no `classifiers`, and shields reads supported versions from the `Programming Language :: Python :: *` classifiers rather than from `requires-python`. The static badge states what is actually true today, and matches the CI matrix.