### PR TITLE
Raise the Read the Docs build to Python 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,9 @@ sphinx:
   configuration: docs/source/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 python:
   install:


### PR DESCRIPTION
## Why

`.readthedocs.yaml` pins `python: "3.11"`, but Sphinx 9.x requires `Python >=3.12`. That makes the hosted Read the Docs build unable to install Sphinx 9 — and **CI cannot catch it**, because `.github/workflows/docs.yml` uses `python-version: "3.x"` (latest). The Actions `build-docs` job therefore goes green on a Sphinx version RTD cannot install.

This blocks #176 (Sphinx 6.2.1 → 9.1.0). That PR is currently green, so merging it as-is would silently break the hosted docs while every check reports success.

## What

- `build.os`: `ubuntu-22.04` → `ubuntu-24.04`
- `build.tools.python`: `3.11` → `3.12`

3.12 is the minimum Sphinx 9.1.0 accepts. No other files change; the docs sources and `docs/requirements.txt` are untouched.

## Verification

Built the docs locally against what #176 would produce (`sphinx==9.1.0` + the `sphinx-rtd-theme==3.1.0` already on develop from #179):

- Python 3.12.12 → `build succeeded`
- Python 3.13 → `build succeeded`, no warnings

`docs/source/conf.py` sets `extensions = []`, so `breathe` and `sphinxemoji` are installed but never loaded — which is why a three-major Sphinx jump is uneventful here.

## Merge order

Merge this first, then rebase and merge #176.