### PR TITLE
Fix NERSC image supervisord crash (missing pkg_resources)

### DIFF
--- a/docker/NERSC/Dockerfile
+++ b/docker/NERSC/Dockerfile
@@ -16,7 +16,9 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-install-project --no-dev $AIDRIN_EXTRAS
 COPY . .
 RUN uv sync --frozen --no-dev $AIDRIN_EXTRAS
-RUN uv pip install gunicorn==23.0.0 supervisor==4.2.5
+# supervisor 4.2.5 imports pkg_resources at startup; setuptools>=82 removed it,
+# so pin setuptools below 82 for the runtime tooling.
+RUN uv pip install gunicorn==23.0.0 supervisor==4.2.5 "setuptools<82"
 
 FROM python:3.13.11-slim-bookworm
 


### PR DESCRIPTION
## Problem

The NERSC all-in-one image crashes on startup:

```
File ".../supervisor/options.py", line 13, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

supervisor 4.2.5 declares `setuptools` as a dependency and imports `pkg_resources`
at startup. `uv pip install supervisor` resolved setuptools to 84.0.0, and
setuptools>=82 removed `pkg_resources`, so supervisord fails to import.

Earlier images worked because the project pinned `setuptools<81` (for dython). Latest
develop bumped to dython 0.7.11, which dropped that need, leaving setuptools
unconstrained -> it resolved to 84 -> supervisor broke.

## Fix

Pin `setuptools<82` when installing the runtime tooling so `pkg_resources` is present:

```
RUN uv pip install gunicorn==23.0.0 supervisor==4.2.5 "setuptools<82"
```

NERSC-only; the local dev image does not use supervisor.

## Verification

- Rebuilt for linux/amd64: setuptools resolves to 81.0.0, `import pkg_resources` succeeds.
- Booted the all-in-one container behind Redis as an arbitrary UID: supervisord starts
  web/worker/beat (all RUNNING), container reports healthy, `GET /inspector` returns 200.
- Republished `registry.nersc.gov/m1248/aidrin:v2026.08.1` and `:develop` with the fix.