### PR TITLE
Share the upload folder across the local compose containers (#210)

### DIFF
--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -5,9 +5,16 @@
 
 name: aidrin-local
 
+# Uploads are handed to Celery tasks by path, so web (writes), worker (reads)
+# and beat (prunes) must all see the same directory.
+volumes:
+  uploads:
+
 # Only `web` builds/tags aidrin:local; worker/beat reuse the tag.
 x-aidrin-app: &aidrin-app
   image: aidrin:local
+  volumes:
+    - uploads:/app/data/uploads
   environment:
     FLASK_CELERY__broker_url: redis://redis:6379/0
     FLASK_CELERY__result_backend: redis://redis:6379/0

--- a/tests/unit/test_docker_compose_uploads.py
+++ b/tests/unit/test_docker_compose_uploads.py
@@ -1,0 +1,80 @@
+"""The local compose stack must share the upload folder across containers.
+
+``web`` saves uploads to ``UPLOAD_FOLDER`` and hands Celery tasks the *path*
+(see ``web.routes.utils.build_file_info``). ``worker`` reads that path back.
+Split across containers without a shared mount, the worker looks at its own
+empty copy of the directory and every path-based metric (feature relevance,
+correlation analysis, conditional demographic disparity) fails with
+"Failed to read the file". The ``delete_old_uploads`` beat task prunes the
+wrong directory for the same reason.
+"""
+
+import os
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+COMPOSE_FILE = os.path.join(REPO_ROOT, "docker", "local", "docker-compose.yml")
+
+# Mirrors ``web.create_app``: ``<project_root>/data/uploads`` with the repo
+# copied to /app in docker/local/Dockerfile.
+UPLOAD_PATH_IN_CONTAINER = "/app/data/uploads"
+
+# Every service that touches UPLOAD_FOLDER: web writes, worker reads, beat prunes.
+SERVICES_NEEDING_UPLOADS = ("web", "worker", "beat")
+
+
+def _upload_mount_source(service):
+    """Return the volume source mounted at the upload path, or None."""
+    for mount in service.get("volumes", []):
+        if isinstance(mount, str):
+            parts = mount.split(":")
+            if len(parts) >= 2 and parts[1] == UPLOAD_PATH_IN_CONTAINER:
+                return parts[0]
+        elif isinstance(mount, dict) and mount.get("target") == UPLOAD_PATH_IN_CONTAINER:
+            return mount.get("source")
+    return None
+
+
+class TestLocalComposeSharesUploads(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(COMPOSE_FILE, encoding="utf-8") as handle:
+            # PyYAML resolves the `<<: *aidrin-app` merge keys, so each service
+            # here is its effective configuration.
+            cls.compose = yaml.safe_load(handle)
+        cls.services = cls.compose["services"]
+
+    def test_every_app_service_mounts_the_upload_folder(self):
+        for name in SERVICES_NEEDING_UPLOADS:
+            with self.subTest(service=name):
+                self.assertIsNotNone(
+                    _upload_mount_source(self.services[name]),
+                    f"service {name!r} has no volume mounted at {UPLOAD_PATH_IN_CONTAINER}",
+                )
+
+    def test_the_upload_mount_is_the_same_volume_everywhere(self):
+        sources = {
+            name: _upload_mount_source(self.services[name])
+            for name in SERVICES_NEEDING_UPLOADS
+        }
+        self.assertEqual(
+            len(set(sources.values())),
+            1,
+            f"services must share one upload volume, got {sources}",
+        )
+
+    def test_the_shared_upload_volume_is_declared(self):
+        source = _upload_mount_source(self.services["web"])
+        # Bind mounts (./path, /abs) need no declaration; named volumes do.
+        if source and not source.startswith((".", "/", "~")):
+            self.assertIn(
+                source,
+                self.compose.get("volumes") or {},
+                f"named volume {source!r} is used but not declared under top-level `volumes`",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #210.

## Root cause

Not a Feature Relevance bug — a compose-topology bug.

`web.create_app()` sets `UPLOAD_FOLDER` to `<project_root>/data/uploads`, i.e. `/app/data/uploads` in the image. `docker/local/docker-compose.yml` runs `web`, `worker` and `beat` as separate containers **with no shared volume**, so each has its own empty copy of that directory.

`/feature-relevance` saves the upload in the *web* container, then hands Celery only the **path** (`build_file_info` → `data_cleaning.delay(..., file_info)`, `web/routes/metrics.py:766`). The worker looks for that path in its own filesystem and misses:

```
web:    -rw-r--r--  3702869  /app/data/uploads/cb345...adult.csv
worker: (empty)
```

```
worker | file_upload        | ERROR | File not found: /app/data/uploads/cb345...adult.csv
worker | feature_relevance  | ERROR | Error reading file: 'str' object has no attribute 'shape'
→ {"trigger":"correlationError","error":"Failed to read the file. Please check the file path and type."}
```

The 3-terminal setup works because all three processes share one filesystem, as does `docker/NERSC` (single container under supervisord).

## Blast radius was wider than reported

Everything crossing the container boundary with a path was broken, not just Feature Relevance:

- **Correlation Analysis** — `{"Error":"Error: string indices must be integers, not 'list'"}`
- **Conditional Demographic Disparity** (fairness)
- **`delete_old_uploads`** beat task — pruning an empty directory, so uploads were never reaped

In-process metrics such as Data Quality were unaffected, which is what made this look metric-specific.

## Fix

A shared named volume on the `x-aidrin-app` anchor, which `web`/`worker`/`beat` all merge via `<<: *aidrin-app`:

```yaml
volumes:
  uploads:

x-aidrin-app: &aidrin-app
  image: aidrin:local
  volumes:
    - uploads:/app/data/uploads
```

`tests/unit/test_docker_compose_uploads.py` guards it: all three services must mount the *same* source at the upload path, and a named volume must be declared. PyYAML resolves the merge keys, so the assertions run against each service's effective config.

## Verification

- New test fails before the change (3 failures), passes after.
- Full unit suite: **592 passed, 9 skipped**.
- End-to-end against a rebuilt stack. Feature Relevance now returns real results instead of the error:

  ```json
  {"Pearson Correlation to Target": {"age": 0.23, "sex_Male": 0.22, "sex_Female": -0.22,
   "race_White": 0.09, "race_Black": -0.09, ...},
   "Feature Relevance Visualization": "<base64 png>"}
  ```

  Correlation Analysis returns its visualizations again, and the worker now sees the upload and writes its `.aidrin.feather` sidecar into the shared volume.