### PR TITLE
Render metric tables at the same precision as their charts (#211)

### DIFF
--- a/aidrin/structured_data_metrics/completeness.py
+++ b/aidrin/structured_data_metrics/completeness.py
@@ -96,10 +96,10 @@ def completeness(self: Task, file_info):
         for bar, val in zip(bars, values):
             if val > 0.15:
                 ax.text(val - 0.01, bar.get_y() + bar.get_height() / 2,
-                        f'{val:.2f}', ha='right', va='center', fontsize=8, color='white', fontweight='bold')
+                        f'{val:.3f}', ha='right', va='center', fontsize=8, color='white', fontweight='bold')
             else:
                 ax.text(val + 0.01, bar.get_y() + bar.get_height() / 2,
-                        f'{val:.2f}', ha='left', va='center', fontsize=8, color=text_color)
+                        f'{val:.3f}', ha='left', va='center', fontsize=8, color=text_color)
 
         fig.tight_layout(pad=0.5)
 

--- a/tests/unit/test_display_precision.py
+++ b/tests/unit/test_display_precision.py
@@ -1,0 +1,92 @@
+"""Metric tables and their charts must agree on decimal precision.
+
+A metric's bar chart is rendered to PNG inside ``aidrin`` with its own format
+string, while the table beside it goes through ``format_dict_values`` in the
+web layer. Because the chart labels are baked in before the web layer ever
+sees the numbers, the two drift apart silently: outlier scores rendered at
+three decimals on the chart were served to the table rounded to two, so
+``age`` read ``0.004`` on the chart and ``0.0`` in the table (issue #211).
+
+These tests pin both ends to the same precision.
+"""
+
+import os
+import re
+import unittest
+
+from web.routes.utils import format_dict_values
+
+DISPLAY_DECIMALS = 3
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+METRICS_DIR = os.path.join(REPO_ROOT, "aidrin", "structured_data_metrics")
+INSPECTOR_JS = os.path.join(REPO_ROOT, "web", "static", "js", "inspector.js")
+
+# Metric modules whose chart labels annotate the same proportion values that
+# format_dict_values rounds for the table. Percentage labels (``.1f%`` in
+# representation_rate/class_imbalance) are a different unit and excluded.
+MODULES_LABELLING_PROPORTIONS = ("outliers.py", "completeness.py", "feature_relevance.py")
+
+# Matches the value labels drawn on bars, e.g. f'{val:.3f}'.
+BAR_LABEL_FORMAT = re.compile(r"\{val:\.(\d+)f\}")
+
+
+class TestTableRounding(unittest.TestCase):
+    """format_dict_values feeds the table; it must not truncate below the chart."""
+
+    def test_values_keep_three_decimals(self):
+        self.assertEqual(
+            format_dict_values({"age": 0.004391757009919842}),
+            {"age": 0.004},
+        )
+
+    def test_rounding_recurses_into_nested_results(self):
+        # Metric payloads nest, e.g. {"Outlier scores": {col: score, ...}}.
+        formatted = format_dict_values(
+            {"Outlier scores": {"education.num": 0.036792481803384416}}
+        )
+        self.assertEqual(formatted, {"Outlier scores": {"education.num": 0.037}})
+
+    def test_small_but_nonzero_scores_survive(self):
+        # The #211 symptom: at two decimals this collapsed to 0.0, contradicting
+        # the 0.004 printed on the chart.
+        self.assertNotEqual(format_dict_values({"age": 0.0044})["age"], 0.0)
+
+    def test_non_numeric_values_pass_through(self):
+        payload = {"Description": "text", "keys": ["a", "b"], "n": 3}
+        self.assertEqual(format_dict_values(payload), payload)
+
+
+class TestChartLabelsMatchTable(unittest.TestCase):
+    """Bar labels are baked into the PNG, so they must be pinned to the same precision."""
+
+    def test_bar_labels_use_the_table_precision(self):
+        for module in MODULES_LABELLING_PROPORTIONS:
+            path = os.path.join(METRICS_DIR, module)
+            with open(path, encoding="utf-8") as handle:
+                found = BAR_LABEL_FORMAT.findall(handle.read())
+            with self.subTest(module=module):
+                self.assertTrue(found, f"no bar value labels found in {module}")
+                self.assertEqual(
+                    sorted(set(found)),
+                    [str(DISPLAY_DECIMALS)],
+                    f"{module} labels bars at {sorted(set(found))} decimals; the table "
+                    f"renders {DISPLAY_DECIMALS}. Keep both in step (issue #211).",
+                )
+
+    def test_the_table_renderer_pads_to_the_same_precision(self):
+        # formatValue() decides the string shown in the scores table. Padding
+        # past DISPLAY_DECIMALS appends zeros the value no longer carries and
+        # makes the table read wider than the chart label beside it.
+        with open(INSPECTOR_JS, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn(
+            f"v.toFixed({DISPLAY_DECIMALS})",
+            source,
+            f"inspector.js formatValue() must render numbers at {DISPLAY_DECIMALS} "
+            "decimals to match the chart labels (issue #211).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/routes/utils.py
+++ b/web/routes/utils.py
@@ -275,13 +275,19 @@ def get_result_or_default(metric, uploaded_file_path, uploaded_file_name):
 # ---------------------------------------------------------------------------
 
 def format_dict_values(d):
-    """Recursively round numeric values in a dict to 2 decimal places."""
+    """Recursively round numeric values in a dict to 3 decimal places.
+
+    Metric charts label their bars at three decimals, and this is what the
+    table beside them renders, so the two must agree. Two decimals collapsed
+    small-but-real scores to ``0.0`` in the table while the chart showed
+    ``0.004`` (issue #211).
+    """
     formatted_dict = {}
     for key, value in d.items():
         if isinstance(value, dict):
             formatted_dict[key] = format_dict_values(value)
         elif isinstance(value, (int, float)):
-            formatted_dict[key] = round(value, 2)
+            formatted_dict[key] = round(value, 3)
         else:
             formatted_dict[key] = value
     return formatted_dict

--- a/web/static/js/inspector.js
+++ b/web/static/js/inspector.js
@@ -3367,8 +3367,11 @@ function isFlatDict(obj) {
 function formatValue(v) {
   if (v === null || v === undefined) return "—";
   if (typeof v === "boolean") return v ? "Yes" : "No";
+  // Results are rounded to 3 decimals server-side (format_dict_values), which
+  // is also what the charts label their bars with — so a 4th decimal here only
+  // ever appended a meaningless zero and made the table disagree with the plot.
   if (typeof v === "number")
-    return Number.isInteger(v) ? v.toString() : v.toFixed(4);
+    return Number.isInteger(v) ? v.toString() : v.toFixed(3);
   if (Array.isArray(v)) return v.length ? v.map(formatValue).join(", ") : "—";
   if (typeof v === "object")
     return Object.keys(v).length ? JSON.stringify(v) : "—";


### PR DESCRIPTION
Fixes #211.

## Cause

Two places set the precision independently, and the chart is rendered to PNG before the web layer ever sees the numbers:

- `aidrin/structured_data_metrics/outliers.py:121,124` labels bars with `f'{val:.3f}'`
- `web/routes/utils.py` (`format_dict_values`) rounded every numeric in every metric result to 2 decimals before it reached the table

So the table lost precision the chart kept. On `adult.csv`:

| feature | raw | chart | table (before) |
|---|---|---|---|
| age | 0.004391757 | 0.004 | **0.0** |
| education.num | 0.036792482 | 0.037 | 0.04 |
| hours.per.week | 0.276649980 | 0.277 | 0.28 |
| Overall outlier score | 0.049757159 | 0.050 | 0.05 |

Rounding inside `outliers.py` cannot fix this — `round(0.037, 2)` still lands on `0.04` afterwards — so the change has to go through `format_dict_values`, which is shared by every metric.

## Changes

- `web/routes/utils.py` — `format_dict_values` rounds to 3 decimals instead of 2.
- `aidrin/structured_data_metrics/completeness.py` — its two bar labels were at `.2f`; bumped to `.3f` so the global change doesn't relocate the same mismatch onto Completeness (its chart would have read `0.99` against a table of `0.993`).
- `web/static/js/inspector.js` — `formatValue()` padded non-integers to `toFixed(4)`. With results rounded to 3 server-side that only ever appended a zero, making the table read `0.0370` next to a chart label of `0.037`; it now renders 3 decimals.
- `tests/unit/test_display_precision.py` — new. Pins `format_dict_values` to 3 decimals, and asserts the bar-label format strings in `outliers.py` / `completeness.py` / `feature_relevance.py` and `formatValue()` in `inspector.js` all use that same precision, since nothing else couples them.

## Result

Chart label against the rendered table cell, `adult.csv`:

| feature | chart | table |
|---|---|---|
| age | 0.004 | 0.004 |
| fnlwgt | 0.030 | 0.030 |
| education.num | 0.037 | 0.037 |
| hours.per.week | 0.277 | 0.277 |
| Overall outlier score | 0.050 | 0.050 |

Exact zeros still render as `0` in the table against `0.000` on the chart. `formatValue` short-circuits on `Number.isInteger`, and a Python `0.0` is indistinguishable from an integer `0` once serialized to JSON. Removing that branch would render every count in the app as `5.000`, so it is left alone.

## Tests

- The new test fails on `develop` (4 failures) and passes with this change.
- Full suite: 736 passed, 11 skipped. No existing test asserted 2- or 4-decimal output.
