### PR TITLE
Fix pgeocode permission error in NERSC image (HIPAA/data-governance)

### DIFF
--- a/docker/NERSC/Dockerfile
+++ b/docker/NERSC/Dockerfile
@@ -42,11 +42,19 @@ ENV PYTHONUNBUFFERED=1 \
     GUNICORN_TIMEOUT=120 \
     HOME=/tmp \
     MPLCONFIGDIR=/tmp/matplotlib \
+    PGEOCODE_DATA_DIR=/app/.cache/pgeocode \
     FLASK_CELERY__broker_url=redis://redis:6379/0 \
     FLASK_CELERY__result_backend=redis://redis:6379/0
 
 WORKDIR /app
 COPY --from=builder /app /app
+
+# Pre-fetch pgeocode's GeoNames data into PGEOCODE_DATA_DIR (under /app) so the HIPAA
+# postal-code check works for the arbitrary non-root UID on Spin: HOME=/tmp/.cache is
+# root-owned and unwritable there, and Spin may block egress. Best-effort at build.
+RUN mkdir -p /app/.cache/pgeocode \
+    && python -c "import pgeocode; pgeocode.Nominatim('us')" \
+    || echo "pgeocode prefetch skipped (offline build); will download at runtime"
 
 # Group-writable (GID 0) so Spin's arbitrary non-root UID can write.
 RUN chgrp -R 0 /app && chmod -R g=u /app


### PR DESCRIPTION
## Problem

Production readiness report fails the Data Governance pillar:

```
Readiness report — data-governance error: [Errno 13] Permission denied: '/tmp/.cache/pgeocode'
```

`hipaa_compliance.detect_hipaa_identifiers` builds a `pgeocode.Nominatim`, which writes
its GeoNames cache to `$HOME/.cache/pgeocode`. The image sets `HOME=/tmp`, and on Spin the
container runs as an arbitrary non-root UID (GID 0) where `/tmp/.cache` is root-owned `0755`,
so `os.makedirs('/tmp/.cache/pgeocode')` is denied. Reproduced locally by running the image
as `--user 1000680000:0`.

## Fix

- Point pgeocode at a cache dir under the group-writable `/app` tree via
  `PGEOCODE_DATA_DIR=/app/.cache/pgeocode` (the arbitrary GID-0 UID can write there,
  same as uploads).
- Pre-fetch the US GeoNames data at build time so the data is baked in and readable —
  robust even if Spin blocks outbound egress. Best-effort (build stays green offline).

NERSC image only. No app-code change.

## Verification

- Rebuilt for linux/amd64; `US.txt` / `US-index.txt` present under `/app/.cache/pgeocode`,
  group-readable.
- As `--user 1000680000:0` (the UID that previously failed with Errno 13),
  `pgeocode.Nominatim('us').query_postal_code('90210')` now returns Beverly Hills, California.