### PR TITLE
Restore correlation analysis for string columns with missing values (pandas v3)

### DIFF
--- a/aidrin/structured_data_metrics/correlation_score.py
+++ b/aidrin/structured_data_metrics/correlation_score.py
@@ -79,9 +79,10 @@ def calc_correlations(self: Task, columns: List[str], file_info, include_visuali
         # Check if there are categorical features
         if not categorical_columns.empty:
             # Categorical-categorical correlations are computed using theil
+            cat_df = df[categorical_columns].astype(object)
             with _ASSOCIATIONS_LOCK:
                 categorical_correlation = associations(
-                    df[categorical_columns], nom_nom_assoc=NOMINAL_NOMINAL_ASSOC, plot=False
+                    cat_df, nom_nom_assoc=NOMINAL_NOMINAL_ASSOC, plot=False
                 )
             logger.debug("Categorical correlation matrix computed:\n%s", categorical_correlation["corr"])
 

--- a/tests/unit/test_correlation_string_dtype.py
+++ b/tests/unit/test_correlation_string_dtype.py
@@ -1,0 +1,43 @@
+"""Regression: categorical correlations with pandas StringDtype + nulls.
+
+dython.associations() defaults to fillna(0.0). Pandas 3 strict ``string``
+columns reject that assignment. Impact on AI and the Correlation Analysis
+metric both call calc_correlations().
+"""
+
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+from aidrin.structured_data_metrics.correlation_score import calc_correlations
+
+
+def _string_dtype_frame():
+    return pd.DataFrame(
+        {
+            "a": pd.array(["x", "y", None, "x"], dtype=pd.StringDtype()),
+            "b": pd.array(["p", "q", "r", "p"], dtype=pd.StringDtype()),
+            "n": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+
+class TestCorrelationStringDtype(unittest.TestCase):
+    def test_string_dtype_with_nulls_returns_scores_not_error(self):
+        file_info = ("/tmp/data.csv", "data.csv", ".csv")
+        with patch(
+            "aidrin.structured_data_metrics.correlation_score.read_file",
+            return_value=_string_dtype_frame(),
+        ):
+            result = calc_correlations(
+                ["a", "b", "n"],
+                file_info,
+                include_visualization=False,
+            )
+
+        self.assertNotIn("Message", result, result.get("Message"))
+        scores = result.get("Correlation Scores")
+        self.assertIsInstance(scores, dict)
+        self.assertTrue(scores)
+        self.assertIn("a vs b", scores)


### PR DESCRIPTION
dython.associations() imputes nulls with 0.0 by default, which pandas v3 string dtypes reject. Cast categoricals to object before the call so Impact on AI, Correlation Analysis, and headless correlations work again. Add a regression test for StringDtype columns with missing values.

# Related Issues / Pull Requests

#232 

# Description

Fixes categorical correlation analysis on pandas v3 when string columns contain nulls. `calc_correlations()` now casts categorical columns to `object` before calling `dython.associations()`, avoiding a dtype error from dython’s default `fillna(0.0)` imputation.

**Changes**
1. aidrin/structured_data_metrics/correlation_score.py: Cast categorical columns to object before associations(). Preserves existing dython NaN handling and Theil’s U behavior on pandas v2.
2. tests/unit/test_correlation_string_dtype.py: Regression test with StringDtype columns and nulls; asserts correlation scores are returned instead of an error.


# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
