### PR TITLE
Feat/custom metrics remedy before after

### DIFF
--- a/aidrin/headless/api.py
+++ b/aidrin/headless/api.py
@@ -1054,14 +1054,19 @@ def run_custom_metric_remedy(
     output_dir: Optional[str] = None,
     file_type: Optional[str] = None,
     file_name: Optional[str] = None,
+    diff: bool = False,
     **kwargs,
-) -> str:
+) -> Any:
     """Execute `remedy` on a custom metric and save the returned DataFrame as CSV.
 
     The input dataset may be any format supported by file_handling/readers/
     (CSV, Excel, JSON, NPZ, HDF5, Parquet); the remedied output is always
     written as CSV, since remediated data doesn't round-trip losslessly back
     into every original format (e.g. JSON/NPZ/HDF5 are flattened on read).
+
+    Returns the saved CSV path (str) by default. When `diff` is true, instead
+    re-runs `metric()` on the remedied data and returns
+    `{"before": ..., "after": ..., "_saved_to": <path>}`.
     """
     script_path = _resolve_custom_script(metric_name)
     clean_name = os.path.splitext(os.path.basename(script_path))[0]
@@ -1112,4 +1117,15 @@ def run_custom_metric_remedy(
     output_path = os.path.join(target_dir, filename)
     remedied.to_csv(output_path, index=False)
 
-    return output_path
+    if not diff:
+        return output_path
+
+    after_agent = module.CustomDR(dataset=remedied, **kwargs)
+    _log_progress(f"Re-running metric on remedied data for: {metric_name}", kwargs.get("verbose", False))
+    after_results = after_agent.metric(**kwargs)
+    if not isinstance(after_results, dict):
+        raise TypeError(
+            f"metric() in '{script_path}' must return a dict, got {type(after_results).__name__}"
+        )
+
+    return {"before": metric_results, "after": after_results, "_saved_to": output_path}

--- a/aidrin/headless/cli.py
+++ b/aidrin/headless/cli.py
@@ -874,6 +874,11 @@ def main() -> None:
         help="Run metric (default) or remedy; remedy output is always saved as CSV",
     )
     custom_parser.add_argument("--file-type", dest="file_type", default=None, help="Input file type override (csv, parquet, xlsx, hdf5, json, npz)")
+    custom_parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="With the remedy action, also re-run metric() on the remedied data and print before/after results",
+    )
     _configure_minimal_run_args(custom_parser)
 
     batch_parser = subparsers.add_parser("batch", help="Run metrics from config file (JSON or YAML)")
@@ -1013,15 +1018,25 @@ def main() -> None:
 
             # Custom metrics/remedies
             if args.metric == "custom":
+                diff = getattr(args, "diff", False)
+                if diff and args.action != "remedy":
+                    sys.stderr.write("Error: --diff is only valid with the remedy action\n")
+                    sys.exit(2)
                 if args.action == "remedy":
-                    output_path = run_custom_metric_remedy(
+                    result = run_custom_metric_remedy(
                         args.name,
                         args.file_path,
                         output_dir=None,
                         file_type=getattr(args, "file_type", None),
+                        diff=diff,
                         **_build_run_kwargs(args),
                     )
-                    print(f"Remedied data saved to: {output_path}")
+                    if diff:
+                        saved_to = result.pop("_saved_to")
+                        _dump_result(result)
+                        print(f"\nRemedied data saved to: {saved_to}")
+                    else:
+                        print(f"Remedied data saved to: {result}")
                     return
                 result = executor.run_metric(
                     args.name,

--- a/aidrin/mcp/server.py
+++ b/aidrin/mcp/server.py
@@ -408,6 +408,7 @@ def run_custom_remedy(
     file_path: str,
     output_dir: str | None = None,
     file_type: str | None = None,
+    diff: bool = False,
 ) -> str:
     """
     Run the remedy() method of a CustomDR class, apply it to the dataset,
@@ -421,13 +422,24 @@ def run_custom_remedy(
         output_dir: Directory to write the remedied CSV.
                     Defaults to <script_dir>/remedy_data/.
         file_type: Optional file-type override (csv, parquet, xlsx, hdf5, json, npz).
+        diff: If true, also re-run metric() on the remedied data and include
+              "before"/"after" results in the response.
     """
-    saved_path = run_custom_metric_remedy(
+    result = run_custom_metric_remedy(
         metric_name_or_path,
         file_path,
         output_dir=output_dir,
         file_type=file_type,
+        diff=diff,
     )
+    if diff:
+        saved_path = result.pop("_saved_to")
+        return _dumps({
+            **result,
+            "remedied_file": saved_path,
+            "message": f"Remedied dataset saved to {saved_path}",
+        })
+    saved_path = result
     return _dumps({
         "remedied_file": saved_path,
         "message": f"Remedied dataset saved to {saved_path}",

--- a/tests/integration/test_custom_metrics.py
+++ b/tests/integration/test_custom_metrics.py
@@ -95,7 +95,10 @@ def test_custom_metrics_run_on_json_upload(uploaded_client_json):
     assert response.status_code == 200
     data = response.get_json()
     evaluation = data["Custom Metric Evaluation"]
-    assert evaluation["row_count"] == 3
+    # When remedy runs, metric() is re-run on the remedied data too, so the
+    # result is a before/after diff rather than a flat metric_results dict.
+    assert evaluation["before"]["row_count"] == 3
+    assert evaluation["after"]["row_count"] == 3
     # Remedy output must be a .csv file regardless of the .json input.
     assert evaluation["apply_remedy"].endswith(".csv")
 
@@ -199,3 +202,82 @@ class CustomDR(BaseDRAgent):
     response = _save_and_run(uploaded_client, code)
     assert response.status_code == 400
     assert "must return a dictionary" in response.get_json()["error"]
+
+
+# -------------------------------------------------
+# Custom metrics run — before/after diff on remedy
+# -------------------------------------------------
+
+_DIFF_CODE = """
+from aidrin.custom_metrics.base_dr import BaseDRAgent
+
+class CustomDR(BaseDRAgent):
+    def metric(self, **kwargs):
+        return {"column_count": len(self.dataset.columns)}
+
+    def remedy(self, **kwargs):
+        df = self.dataset.copy()
+        df["new_flag"] = True
+        return df
+"""
+
+
+def test_custom_metrics_remedy_shows_before_and_after_diff(uploaded_client):
+    with uploaded_client.session_transaction() as sess:
+        if "session_id" not in sess:
+            sess["session_id"] = "test-session-diff"
+    uploaded_client.post(
+        "/save-custom-metric-text", data={"metric_code": _DIFF_CODE, "apply_remedy": "no"}
+    )
+    response = uploaded_client.post("/custom-metrics?return_type=json", data={"apply_remedy": "yes"})
+    assert response.status_code == 200
+    evaluation = response.get_json()["Custom Metric Evaluation"]
+    assert evaluation["before"] == {"column_count": 4}
+    assert evaluation["after"] == {"column_count": 5}
+    assert evaluation["apply_remedy"].endswith(".csv")
+
+
+def test_custom_metrics_without_remedy_keeps_flat_shape(uploaded_client):
+    """When Apply Remedy isn't checked, the response stays the original flat
+    metric_results dict — the before/after shape only applies to remedy runs."""
+    with uploaded_client.session_transaction() as sess:
+        if "session_id" not in sess:
+            sess["session_id"] = "test-session-flat"
+    uploaded_client.post(
+        "/save-custom-metric-text", data={"metric_code": _DIFF_CODE, "apply_remedy": "no"}
+    )
+    response = uploaded_client.post("/custom-metrics?return_type=json", data={"apply_remedy": "no"})
+    assert response.status_code == 200
+    evaluation = response.get_json()["Custom Metric Evaluation"]
+    assert evaluation == {"column_count": 4}
+
+
+def test_custom_metrics_runtime_error_in_after_metric_returns_400(uploaded_client, caplog):
+    """metric() succeeding before remedy but failing when re-run on the
+    remedied data must surface its own 400, with the exception text kept out
+    of the HTTP response (same information-exposure precaution as the other
+    error paths) but still logged server-side."""
+    code = """
+from aidrin.custom_metrics.base_dr import BaseDRAgent
+
+_calls = {"n": 0}
+
+class CustomDR(BaseDRAgent):
+    def metric(self, **kwargs):
+        _calls["n"] += 1
+        if _calls["n"] == 1:
+            return {"ok": True}
+        raise ValueError("boom-after")
+
+    def remedy(self, **kwargs):
+        return self.dataset.copy()
+"""
+    with uploaded_client.session_transaction() as sess:
+        if "session_id" not in sess:
+            sess["session_id"] = "test-session-after-error"
+    uploaded_client.post("/save-custom-metric-text", data={"metric_code": code, "apply_remedy": "no"})
+    response = uploaded_client.post("/custom-metrics?return_type=json", data={"apply_remedy": "yes"})
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "boom-after" not in data["error"]
+    assert "boom-after" in caplog.text

--- a/tests/unit/test_api_custom_metrics.py
+++ b/tests/unit/test_api_custom_metrics.py
@@ -178,6 +178,52 @@ _METRIC_RESULTS_SCRIPT = textwrap.dedent(
 )
 
 
+_NULL_COUNT_SCRIPT = textwrap.dedent(
+    """
+    from aidrin.custom_metrics.base_dr import BaseDRAgent
+
+    class CustomDR(BaseDRAgent):
+        def metric(self, **kwargs):
+            return {"null_count": int(self.dataset.isna().sum().sum())}
+
+        def remedy(self, **kwargs):
+            return self.dataset.fillna(0)
+    """
+)
+
+
+def test_run_custom_metric_remedy_diff_returns_before_and_after(tmp_path):
+    """diff=True should re-run metric() on the remedied data and report both
+    results, without changing the on-disk CSV output the non-diff path relies
+    on."""
+    script_path = tmp_path / "null_count_audit.py"
+    script_path.write_text(_NULL_COUNT_SCRIPT)
+    file_path = tmp_path / "data.csv"
+    pd.DataFrame({"age": [25, None, 35, 40]}).to_csv(file_path, index=False)
+    output_dir = tmp_path / "remedy_out"
+
+    result = run_custom_metric_remedy(
+        str(script_path), str(file_path), output_dir=str(output_dir), diff=True
+    )
+
+    assert result["before"] == {"null_count": 1}
+    assert result["after"] == {"null_count": 0}
+    assert result["_saved_to"].endswith(".csv")
+    assert os.path.exists(result["_saved_to"])
+
+
+def test_run_custom_metric_remedy_without_diff_returns_path_string(tmp_path, script_path):
+    """Default (diff=False) behavior must stay exactly what it was before the
+    diff option existed, since it's shared with the MCP tool."""
+    file_path = _write_csv(tmp_path)
+    output_dir = tmp_path / "remedy_out"
+
+    result = run_custom_metric_remedy(script_path, file_path, output_dir=str(output_dir))
+
+    assert isinstance(result, str)
+    assert result.endswith(".csv")
+
+
 def test_run_custom_metric_remedy_passes_metric_results_to_remedy(tmp_path):
     """The web UI runs metric() before remedy() and passes the results in
     (web/routes/custom.py), matching the contract documented in the

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -744,6 +744,26 @@ class TestCustomMetricMultiFormat(unittest.TestCase):
         self.assertTrue(saved_path.endswith(".csv"))
         self.assertTrue(os.path.exists(saved_path))
 
+    def test_run_custom_remedy_with_diff_flag_prints_before_after_json(self):
+        stdout, stderr, code = _run_cli(
+            "run", "custom", self.script, self.parquet, "remedy", "--file-type", "parquet", "--diff"
+        )
+        self.assertEqual(code, 0, stderr)
+        self.assertIn("Remedied data saved to:", stdout)
+        json_part, _, saved_line = stdout.partition("\n\nRemedied data saved to:")
+        data = json.loads(json_part)
+        self.assertEqual(data["before"], {"row_count": 5})
+        self.assertEqual(data["after"], {"row_count": 5})
+        saved_path = saved_line.strip()
+        self.assertTrue(os.path.exists(saved_path))
+
+    def test_run_custom_metric_with_diff_flag_errors(self):
+        """--diff only makes sense alongside the remedy action."""
+        stdout, stderr, code = _run_cli(
+            "run", "custom", self.script, self.parquet, "metric", "--file-type", "parquet", "--diff"
+        )
+        self.assertNotEqual(code, 0)
+
     def test_run_custom_metric_on_hyphenated_path(self):
         """`metric` used to route through run_metric(), which lowercased and
         underscored the script path before resolving it — corrupting any

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -130,6 +130,48 @@ def test_run_custom_remedy_saves_csv_for_non_csv_input(tmp_path):
     assert os.path.exists(result["remedied_file"])
 
 
+_NULL_COUNT_SCRIPT = """
+from aidrin.custom_metrics.base_dr import BaseDRAgent
+
+class CustomDR(BaseDRAgent):
+    def metric(self, **kwargs):
+        return {"null_count": int(self.dataset.isna().sum().sum())}
+
+    def remedy(self, **kwargs):
+        return self.dataset.fillna(0)
+"""
+
+
+def test_run_custom_remedy_with_diff_returns_before_and_after(tmp_path):
+    script_path = os.path.join(str(tmp_path), "null_count_audit.py")
+    with open(script_path, "w") as f:
+        f.write(_NULL_COUNT_SCRIPT)
+    csv_path = os.path.join(str(tmp_path), "data.csv")
+    pd.DataFrame({"age": [18, None, 70]}).to_csv(csv_path, index=False)
+    output_dir = str(tmp_path / "remedy_out")
+
+    result = json.loads(
+        run_custom_remedy(script_path, csv_path, output_dir=output_dir, diff=True)
+    )
+
+    assert result["before"] == {"null_count": 1}
+    assert result["after"] == {"null_count": 0}
+    assert result["remedied_file"].endswith(".csv")
+    assert os.path.exists(result["remedied_file"])
+
+
+def test_run_custom_remedy_without_diff_keeps_original_response_shape(tmp_path):
+    script_path = _write_script(str(tmp_path))
+    parquet_path = _write_parquet(str(tmp_path))
+    output_dir = str(tmp_path / "remedy_out")
+
+    result = json.loads(
+        run_custom_remedy(script_path, parquet_path, output_dir=output_dir, file_type="parquet")
+    )
+
+    assert set(result.keys()) == {"remedied_file", "message"}
+
+
 # ---------------------------------------------------------------------------
 # File reference validation
 # ---------------------------------------------------------------------------

--- a/web/routes/custom.py
+++ b/web/routes/custom.py
@@ -134,9 +134,30 @@ def custom_metrics():
                 remedy_filepath = os.path.join(remedy_folder, remedy_filename)
                 new_data.to_csv(remedy_filepath, index=False)
 
-                final_dict["Custom Metric Evaluation"]["apply_remedy"] = url_for(
-                    "custom.download_remedy", filename=remedy_filename
-                )
+                # Re-run metric() on the remedied data so the panel shows the
+                # effect of the remedy, not just the pre-remedy result.
+                try:
+                    after_instance = custom_metric_class(dataset=new_data)
+                    after_results = after_instance.metric()
+                except Exception as e:
+                    metric_time_log.error(
+                        "Custom metric() raised on remedied data: %s", e, exc_info=True
+                    )
+                    return jsonify(
+                        {"error": "Error running metric() on the remedied data."}
+                    ), 400
+
+                if not isinstance(after_results, dict):
+                    return jsonify({
+                        "error": f"{custom_metric_class.__name__}.metric() must return a "
+                                 f"dictionary, got {type(after_results).__name__}."
+                    }), 400
+
+                final_dict["Custom Metric Evaluation"] = {
+                    "before": metric_results,
+                    "after": after_results,
+                    "apply_remedy": url_for("custom.download_remedy", filename=remedy_filename),
+                }
 
             final_dict = ensure_json_serializable(final_dict)
 

--- a/web/static/js/inspector.js
+++ b/web/static/js/inspector.js
@@ -1404,18 +1404,90 @@ function renderFileReferenceMetadataTable(rows) {
   return html + `</tbody></table></div></div>`;
 }
 
+// Flattens a nested metric dict into {"outer / inner": value} so before/after
+// dicts with matching shapes can be compared row-by-row in one table.
+function flattenMetricDict(obj, prefix) {
+  const result = {};
+  for (const [k, v] of Object.entries(obj || {})) {
+    const label = prefix ? `${prefix} | ${k}` : k;
+    if (isObject(v) && Object.keys(v).length > 0) {
+      Object.assign(result, flattenMetricDict(v, label));
+    } else {
+      result[label] = v;
+    }
+  }
+  return result;
+}
+
+// Renders the custom-metric remedy "before" and "after" dicts as a single
+// Metric | Before | After comparison table instead of two stacked sections.
+function renderBeforeAfterTable(before, after) {
+  const beforeFlat = flattenMetricDict(before);
+  const afterFlat = flattenMetricDict(after);
+
+  const keys = [];
+  const seen = new Set();
+  for (const k of [...Object.keys(beforeFlat), ...Object.keys(afterFlat)]) {
+    if (!seen.has(k)) {
+      seen.add(k);
+      keys.push(k);
+    }
+  }
+
+  let html = `<div class="mb-4">`;
+  html += `<h4 class="text-xs font-semibold mb-2 uppercase tracking-wider text-gray-500 dark:text-gray-400">Before / After Remedy</h4>`;
+  html += `<div class="relative overflow-x-auto rounded-lg shadow-sm">`;
+  html += `<table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">`;
+  html += `<thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400"><tr>`;
+  html += `<th scope="col" class="px-4 py-2.5">Metric</th>`;
+  html += `<th scope="col" class="px-4 py-2.5 text-right">Before</th>`;
+  html += `<th scope="col" class="px-4 py-2.5 text-right">After</th>`;
+  html += `</tr></thead><tbody>`;
+  keys.forEach((key, idx) => {
+    const stripe =
+      idx % 2 === 0
+        ? "bg-white dark:bg-gray-800"
+        : "bg-gray-50 dark:bg-gray-700/50";
+    const hasBefore = Object.prototype.hasOwnProperty.call(beforeFlat, key);
+    const hasAfter = Object.prototype.hasOwnProperty.call(afterFlat, key);
+    const changed =
+      hasBefore && hasAfter && beforeFlat[key] !== afterFlat[key];
+    html += `<tr class="${stripe} border-b dark:border-gray-700">`;
+    html += `<td class="px-4 py-2 font-medium text-gray-900 dark:text-white whitespace-nowrap">${escapeHtml(key)}</td>`;
+    html += `<td class="px-4 py-2 text-right font-mono text-xs">${hasBefore ? escapeHtml(formatValue(beforeFlat[key])) : "—"}</td>`;
+    html += `<td class="px-4 py-2 text-right font-mono text-xs${changed ? " text-green-600 dark:text-green-400 font-semibold" : ""}">${hasAfter ? escapeHtml(formatValue(afterFlat[key])) : "—"}</td>`;
+    html += `</tr>`;
+  });
+  html += `</tbody></table></div></div>`;
+  return html;
+}
+
 /**
  * Render scores section. Detects structure and picks the best layout:
  * - Flat dict of {key: primitive} → compact key-value table
  * - Nested dict → collapsible tree with indented sections
  * - Array → numbered list
  * - Scalar → inline value
+ * - Sibling "before"/"after" dicts (custom-metric remedy comparison) → one
+ *   side-by-side comparison table instead of two stacked sections
  */
 function renderScoresSection(scores, depth) {
   depth = depth || 0;
   let html = "";
 
+  const hasBeforeAfter =
+    isObject(scores.before) &&
+    isObject(scores.after) &&
+    Object.keys(scores.before).length > 0;
+
   for (const [key, value] of Object.entries(scores)) {
+    if (hasBeforeAfter && key === "before") {
+      html += renderBeforeAfterTable(scores.before, scores.after);
+      continue;
+    }
+    if (hasBeforeAfter && key === "after") {
+      continue; // merged into the before/after table above
+    }
     // Flat dict of {feature: number} → Flowbite striped table
     if (isObject(value) && isFlatDict(value) && Object.keys(value).length > 0) {
       const count = Object.keys(value).length;

--- a/web/static/js/inspector.js
+++ b/web/static/js/inspector.js
@@ -1450,8 +1450,7 @@ function renderBeforeAfterTable(before, after) {
         : "bg-gray-50 dark:bg-gray-700/50";
     const hasBefore = Object.prototype.hasOwnProperty.call(beforeFlat, key);
     const hasAfter = Object.prototype.hasOwnProperty.call(afterFlat, key);
-    const changed =
-      hasBefore && hasAfter && beforeFlat[key] !== afterFlat[key];
+    const changed = hasBefore && hasAfter && beforeFlat[key] !== afterFlat[key];
     html += `<tr class="${stripe} border-b dark:border-gray-700">`;
     html += `<td class="px-4 py-2 font-medium text-gray-900 dark:text-white whitespace-nowrap">${escapeHtml(key)}</td>`;
     html += `<td class="px-4 py-2 text-right font-mono text-xs">${hasBefore ? escapeHtml(formatValue(beforeFlat[key])) : "—"}</td>`;

--- a/web/templates/_panels/_custom_metrics.html
+++ b/web/templates/_panels/_custom_metrics.html
@@ -12,7 +12,7 @@
           <li>Click <strong>Save</strong> any time you change the code. <strong>Submit always runs the last saved version</strong>, not whatever is currently typed in the editor.</li>
           <li>If you want to download the remedied dataset, check the <strong>Apply Remedy</strong> box below before clicking Submit. If it is left unchecked, <code class="text-xs bg-gray-100 dark:bg-gray-700 px-1 py-0.5 rounded">remedy()</code> will not run and no download link will appear, even if you wrote one.</li>
           <li>Click <strong>Submit</strong> to run your code against the currently uploaded dataset.</li>
-          <li>Metric results appear below. If <strong>Apply Remedy</strong> was checked, a download link for the remedied dataset is included with the results (always a <strong>CSV</strong> file, regardless of the original format).</li>
+          <li>Metric results appear below. If <strong>Apply Remedy</strong> was checked, <code class="text-xs bg-gray-100 dark:bg-gray-700 px-1 py-0.5 rounded">metric()</code> is re-run on the remedied data and the results show a <strong>before</strong>/<strong>after</strong> comparison, plus a download link for the remedied dataset (always a <strong>CSV</strong> file, regardless of the original format).</li>
         </ol>
       </div>
 


### PR DESCRIPTION
# Related Issues / Pull Requests

N/A

# Description

Adds a before/after comparison for custom metric remedies: when a remedy is applied to a dataset, metric() is now re-run on the remedied data so users can see the effect of the remedy alongside the original results, instead of only getting a download link for the remedied CSV. The web UI renders this comparison as a single side-by-side table.

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote documentation
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
