### PR TITLE
Keep the LLM API key when clearing the session

### DIFF
--- a/tests/integration/test_globus.py
+++ b/tests/integration/test_globus.py
@@ -846,3 +846,42 @@ def test_disconnect_clears_negotiation_and_task_context(client, monkeypatch):
         assert "globus_active_tasks" not in flask_session
         assert "globus_task_contexts" not in flask_session
         assert "globus_endpoint_negotiation" not in flask_session
+
+
+def test_globus_auth_survives_clear(client):
+    """Clearing the loaded dataset must not sign the user out of Globus.
+
+    /clear ends one dataset configuration; /globus/disconnect is the explicit
+    sign-out. Wiping the tokens on /clear forced a full OAuth round trip just
+    to load a second remote dataset.
+    """
+    if not is_globus_available():
+        return
+
+    _authenticate(client)
+    with client.session_transaction() as flask_session:
+        flask_session["globus_endpoint_id"] = "endpoint-uuid"
+        flask_session["globus_file_path"] = "/remote/manifest.csv"
+        flask_session["globus_file_name"] = "manifest.csv"
+
+    response = client.post("/clear")
+    assert response.status_code in (200, 302)
+
+    assert client.get("/globus/status").get_json()["authenticated"] is True
+
+    # The dataset itself is still cleared.
+    with client.session_transaction() as flask_session:
+        assert "globus_file_path" not in flask_session
+        assert "globus_file_name" not in flask_session
+
+
+def test_globus_disconnect_clears_auth_after_clear(client):
+    """/globus/disconnect remains the way to actually sign out."""
+    if not is_globus_available():
+        return
+
+    _authenticate(client)
+    client.post("/clear")
+    client.post("/globus/disconnect")
+
+    assert client.get("/globus/status").get_json()["authenticated"] is False

--- a/tests/integration/test_llm.py
+++ b/tests/integration/test_llm.py
@@ -108,3 +108,24 @@ def test_explain_metric_without_openai():
             "api_key": "key",
             "model": "m",
         })
+
+
+def test_llm_config_survives_clear(client):
+    """Clearing the session to start a new configuration keeps the API key.
+
+    Regression test for issue #155: /clear used to wipe the whole session,
+    so users had to re-enter their API key for every dataset.
+    """
+    if not _HAS_OPENAI:
+        return
+    client.post("/llm/configure", json={
+        "api_base": "https://api.openai.com/v1",
+        "api_key": "sk-test-key",
+        "model": "gpt-4o-mini",
+    })
+
+    response = client.post("/clear")
+    assert response.status_code in (200, 302)
+
+    data = client.get("/llm/status").get_json()
+    assert data["configured"] is True

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -230,11 +230,18 @@ def clear_file():
     # Capture this session's own files before clearing the session.
     owned_files = session.get("owned_files", [])
 
+    # Settings that belong to the user, not to the dataset being cleared, so
+    # they survive starting a new configuration (e.g. the LLM API key).
+    llm_config = session.get("llm_config")
+
     session.pop("uploaded_file_path", None)
     session.pop("uploaded_file_name", None)
     session.pop("uploaded_file_type", None)
     session.pop("minimize_preview", None)
     session.clear()
+
+    if llm_config:
+        session["llm_config"] = llm_config
 
     try:
         for file_path in owned_files:

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -208,6 +208,11 @@ def retrieve_uploaded_file():
     return jsonify({"error": "No file path found"}), 404
 
 
+# Session keys /clear keeps: user-level settings and credentials that are not
+# tied to the dataset being cleared.
+PRESERVED_ON_CLEAR = ("llm_config", "globus_tokens", "globus_authenticated")
+
+
 @core_bp.route("/clear", methods=["GET", "POST"])
 def clear_file():
     file_upload_time_log.info("Clearing File")
@@ -230,9 +235,12 @@ def clear_file():
     # Capture this session's own files before clearing the session.
     owned_files = session.get("owned_files", [])
 
-    # Settings that belong to the user, not to the dataset being cleared, so
-    # they survive starting a new configuration (e.g. the LLM API key).
-    llm_config = session.get("llm_config")
+    # State that belongs to the user rather than to the dataset being cleared,
+    # so it survives starting a new configuration. Globus sign-out has its own
+    # explicit action (/globus/disconnect), as does the LLM key (/llm/disconnect).
+    preserved = {
+        key: session[key] for key in PRESERVED_ON_CLEAR if key in session
+    }
 
     session.pop("uploaded_file_path", None)
     session.pop("uploaded_file_name", None)
@@ -240,8 +248,7 @@ def clear_file():
     session.pop("minimize_preview", None)
     session.clear()
 
-    if llm_config:
-        session["llm_config"] = llm_config
+    session.update(preserved)
 
     try:
         for file_path in owned_files:


### PR DESCRIPTION
Fixes #155.

## Root cause

`POST /clear` — wired to both the "Clear file" ✕ and the "Clear session and start over" button in the topbar — calls `session.clear()` to drop the loaded dataset. That also wiped `llm_config`.

The session is the only source of truth for the LLM settings: `/llm/status`, the `llm_configured` template flag (`web/routes/core.py:141`) and `window.AIDRIN_LLM_ENABLED` (`web/templates/inspector.html:84`) all read it. So one wipe forgot the key everywhere, and users had to re-enter it for every dataset.

## Change

`clear_file` now captures `llm_config` before the clear and restores it after — the same pattern already used for `owned_files`.

A regression test in `tests/integration/test_llm.py` covers configure → `/clear` → `/llm/status`. It fails on `develop` and passes with the fix.

## Verification

- `tests/integration` — 174 passed, 3 skipped
- `tests/unit` — 792 passed, 104 skipped, 208 subtests