### PR TITLE
Stay signed in to Globus when clearing the session

### DIFF
--- a/tests/integration/test_globus.py
+++ b/tests/integration/test_globus.py
@@ -846,3 +846,42 @@ def test_disconnect_clears_negotiation_and_task_context(client, monkeypatch):
         assert "globus_active_tasks" not in flask_session
         assert "globus_task_contexts" not in flask_session
         assert "globus_endpoint_negotiation" not in flask_session
+
+
+def test_globus_auth_survives_clear(client):
+    """Clearing the loaded dataset must not sign the user out of Globus.
+
+    /clear ends one dataset configuration; /globus/disconnect is the explicit
+    sign-out. Wiping the tokens on /clear forced a full OAuth round trip just
+    to load a second remote dataset.
+    """
+    if not is_globus_available():
+        return
+
+    _authenticate(client)
+    with client.session_transaction() as flask_session:
+        flask_session["globus_endpoint_id"] = "endpoint-uuid"
+        flask_session["globus_file_path"] = "/remote/manifest.csv"
+        flask_session["globus_file_name"] = "manifest.csv"
+
+    response = client.post("/clear")
+    assert response.status_code in (200, 302)
+
+    assert client.get("/globus/status").get_json()["authenticated"] is True
+
+    # The dataset itself is still cleared.
+    with client.session_transaction() as flask_session:
+        assert "globus_file_path" not in flask_session
+        assert "globus_file_name" not in flask_session
+
+
+def test_globus_disconnect_clears_auth_after_clear(client):
+    """/globus/disconnect remains the way to actually sign out."""
+    if not is_globus_available():
+        return
+
+    _authenticate(client)
+    client.post("/clear")
+    client.post("/globus/disconnect")
+
+    assert client.get("/globus/status").get_json()["authenticated"] is False

--- a/web/routes/core.py
+++ b/web/routes/core.py
@@ -208,6 +208,11 @@ def retrieve_uploaded_file():
     return jsonify({"error": "No file path found"}), 404
 
 
+# Session keys /clear keeps: user-level settings and credentials that are not
+# tied to the dataset being cleared.
+PRESERVED_ON_CLEAR = ("llm_config", "globus_tokens", "globus_authenticated")
+
+
 @core_bp.route("/clear", methods=["GET", "POST"])
 def clear_file():
     file_upload_time_log.info("Clearing File")
@@ -230,9 +235,12 @@ def clear_file():
     # Capture this session's own files before clearing the session.
     owned_files = session.get("owned_files", [])
 
-    # Settings that belong to the user, not to the dataset being cleared, so
-    # they survive starting a new configuration (e.g. the LLM API key).
-    llm_config = session.get("llm_config")
+    # State that belongs to the user rather than to the dataset being cleared,
+    # so it survives starting a new configuration. Globus sign-out has its own
+    # explicit action (/globus/disconnect), as does the LLM key (/llm/disconnect).
+    preserved = {
+        key: session[key] for key in PRESERVED_ON_CLEAR if key in session
+    }
 
     session.pop("uploaded_file_path", None)
     session.pop("uploaded_file_name", None)
@@ -240,8 +248,7 @@ def clear_file():
     session.pop("minimize_preview", None)
     session.clear()
 
-    if llm_config:
-        session["llm_config"] = llm_config
+    session.update(preserved)
 
     try:
         for file_path in owned_files:


### PR DESCRIPTION
> **Stacked on #243.** Both PRs edit the same block of `clear_file`, so this one is based on `bugfix/llm-api-key-lost-on-clear` to keep the diff clean. Once #243 merges, retarget this to `develop` — or merge #243 into this branch and take them together.

Follow-up to the collateral damage noticed while fixing #155. No issue filed for this one yet.

## Root cause

`POST /clear` ends one dataset configuration, but `session.clear()` also dropped `globus_tokens` and `globus_authenticated`.

The remote-file panel gates on `globus_authenticated` (`web/templates/_components/globus_panel.html:4`), so clearing a file bounced the user back to the "Sign in with Globus" screen and forced a full OAuth round trip just to load a second remote dataset — even though `/globus/disconnect` already exists as the explicit sign-out.

The intent in the code is file-scoped: `clear_file` deliberately cancels active tasks and drops the cached summary. The sign-out was collateral from the blanket `session.clear()`.

## Change

Generalises the single preserved key introduced in #243 into a named tuple and adds the two Globus auth keys:

```python
PRESERVED_ON_CLEAR = ("llm_config", "globus_tokens", "globus_authenticated")
```

Everything dataset-scoped is still cleared: `globus_endpoint_id`, `globus_file_path` / `_name` / `_type`, `globus_active_tasks`, `globus_task_contexts`, the endpoint negotiation record, and the cached summary. `/globus/disconnect` still signs the user out.

`globus_endpoint_id` is deliberately *not* preserved — the UUID field in the panel is a plain input that is never pre-filled from the session, so the session copy is only a server-side mirror set at submit time. Keeping it would leave a stale pointer to a dataset that no longer exists.

## Verification

Two regression tests in `tests/integration/test_globus.py` cover both halves — auth survives `/clear`, and `/globus/disconnect` still clears it afterwards. The first fails on the base branch (`assert False is True`) and passes with the fix.

Full suite with `[llm]` and `[globus]` both installed, so the Globus tests actually run rather than early-returning: **968 passed, 107 skipped, 208 subtests**.